### PR TITLE
expose a method to parent components to focus on text input manually

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -99,7 +99,15 @@ var GooglePlacesAutocomplete = React.createClass({
       },
     };
   },
-  
+
+  /**
+   * This method is exposed to parent components to focus on textInput manually.
+   * @public
+   */
+  triggerFocus: function() {
+    this.refs.textInput.focus();
+  },
+
   getInitialState() {
     var ds = new ListView.DataSource({rowHasChanged: function(r1, r2) {
       if (typeof r1.isLoading !== 'undefined') {


### PR DESCRIPTION
I needed to focus on textInput after navigator transition is over. So, i needed to create a *triggerFocus* method and expose it for parent components.

I think this might be useful for others too.