### PR TITLE
adding textInputProps prop to the autocomplete component

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -347,6 +347,7 @@ const GooglePlacesAutocomplete = React.createClass({
     );
   },
   render() {
+    let { onChangeText, onFocus, ...userProps } = this.props.textInputProps;
     return (
       <View
         style={[defaultStyles.container, this.props.styles.container]}
@@ -355,16 +356,20 @@ const GooglePlacesAutocomplete = React.createClass({
           style={[defaultStyles.textInputContainer, this.props.styles.textInputContainer]}
         >
           <TextInput
+            { ...userProps }
             ref="textInput"
             autoFocus={this.props.autoFocus}
             style={[defaultStyles.textInput, this.props.styles.textInput]}
-            onChangeText={this._onChangeText}
+            onChangeText={
+                onChangeText ? text => {this._onChangeText(text); onChangeText(text)} : this._onChangeText
+            }
             value={this.state.text}
             placeholder={this.props.placeholder}
             // onBlur={this._onBlur}
-            onFocus={this._onFocus}
+            onFocus={
+                onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus
+            }
             clearButtonMode="while-editing"
-            { ...this.props.textInputProps }
           />
         </View>
         {this._getListView()}

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -71,6 +71,7 @@ const GooglePlacesAutocomplete = React.createClass({
     onTimeout: React.PropTypes.func,
     query: React.PropTypes.object,
     styles: React.PropTypes.object,
+    textInputProps: React.PropTypes.object
   },
 
   getDefaultProps() {
@@ -90,6 +91,8 @@ const GooglePlacesAutocomplete = React.createClass({
       },
       styles: {
       },
+      textInputProps: {
+      }
     };
   },
 
@@ -325,7 +328,7 @@ const GooglePlacesAutocomplete = React.createClass({
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}
           automaticallyAdjustContentInsets={false}
-          
+
           {...this.props}
         />
       );
@@ -361,6 +364,7 @@ const GooglePlacesAutocomplete = React.createClass({
             // onBlur={this._onBlur}
             onFocus={this._onFocus}
             clearButtonMode="while-editing"
+            { ...this.props.textInputProps }
           />
         </View>
         {this._getListView()}


### PR DESCRIPTION
Hi,

This PR allows to pass a`textInputProps` that will be passed down to the `TextInput` component for further customization. Tell me if you have any remarks.

Thanks,

Paul