### PR TITLE
Added enableEmptySections prop

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -83,6 +83,7 @@ const GooglePlacesAutocomplete = React.createClass({
     nearbyPlacesAPI: React.PropTypes.string,
     filterReverseGeocodingByTypes: React.PropTypes.array,
     predefinedPlacesAlwaysVisible: React.PropTypes.bool,
+    enableEmptySections: React.PropTypes.bool
   },
 
   getDefaultProps() {
@@ -116,6 +117,7 @@ const GooglePlacesAutocomplete = React.createClass({
       nearbyPlacesAPI: 'GooglePlacesSearch',
       filterReverseGeocodingByTypes: [],
       predefinedPlacesAlwaysVisible: false,
+      enableEmptySections: true
     };
   },
 
@@ -135,7 +137,7 @@ const GooglePlacesAutocomplete = React.createClass({
 
   buildRowsFromResults(results) {
     var res = null;
-    
+
     if (results.length === 0 || this.props.predefinedPlacesAlwaysVisible === true) {
       res = [...this.props.predefinedPlaces];
       if (this.props.currentLocation === true) {
@@ -147,14 +149,14 @@ const GooglePlacesAutocomplete = React.createClass({
     } else {
       res = [];
     }
-    
+
     res = res.map(function(place) {
       return {
         ...place,
         isPredefinedPlace: true,
       }
     });
-    
+
     return [...res, ...results];
   },
 
@@ -177,13 +179,13 @@ const GooglePlacesAutocomplete = React.createClass({
     if (this.refs.textInput) this.refs.textInput.focus();
   },
 
-  /**   
-   * This method is exposed to parent components to blur textInput manually.   
-   * @public   
-   */    
+  /**
+   * This method is exposed to parent components to blur textInput manually.
+   * @public
+   */
   triggerBlur() {
     if (this.refs.textInput) this.refs.textInput.blur();
-  },   
+  },
 
   getCurrentLocation() {
     navigator.geolocation.getCurrentPosition(
@@ -199,8 +201,8 @@ const GooglePlacesAutocomplete = React.createClass({
   },
 
   _enableRowLoader(rowData) {
-    
-    let rows = this.buildRowsFromResults(this._results);    
+
+    let rows = this.buildRowsFromResults(this._results);
     for (let i = 0; i < rows.length; i++) {
       if ((rows[i].place_id === rowData.place_id) || (rows[i].isCurrentLocation === true && rowData.isCurrentLocation === true)) {
         rows[i].isLoading = true;
@@ -275,11 +277,11 @@ const GooglePlacesAutocomplete = React.createClass({
       }));
       request.send();
     } else if (rowData.isCurrentLocation === true) {
-      
+
       // display loader
       this._enableRowLoader(rowData);
-      
-      
+
+
       this.setState({
         text: rowData.description,
       });
@@ -288,7 +290,7 @@ const GooglePlacesAutocomplete = React.createClass({
       delete rowData.isLoading;
 
       this.getCurrentLocation();
-      
+
     } else {
       this.setState({
         text: rowData.description,
@@ -297,16 +299,16 @@ const GooglePlacesAutocomplete = React.createClass({
       this._onBlur();
 
       delete rowData.isLoading;
-      
+
       let predefinedPlace = this._getPredefinedPlace(rowData);
-      
+
       // sending predefinedPlace as details for predefined places
       this.props.onPress(predefinedPlace, predefinedPlace);
     }
   },
   _results: [],
   _requests: [],
-  
+
   _getPredefinedPlace(rowData) {
     if (rowData.isPredefinedPlace !== true) {
       return rowData;
@@ -318,10 +320,10 @@ const GooglePlacesAutocomplete = React.createClass({
     }
     return rowData;
   },
-  
+
   _filterResultsByTypes(responseJSON, types) {
     if (types.length === 0) return responseJSON.results;
-    
+
     var results = [];
     for (let i = 0; i < responseJSON.results.length; i++) {
       let found = false;
@@ -337,8 +339,8 @@ const GooglePlacesAutocomplete = React.createClass({
     }
     return results;
   },
-  
-  
+
+
   _requestNearby(latitude, longitude) {
     this._abortRequests();
     if (latitude !== undefined && longitude !== undefined && latitude !== null && longitude !== null) {
@@ -352,9 +354,9 @@ const GooglePlacesAutocomplete = React.createClass({
         }
         if (request.status === 200) {
           const responseJSON = JSON.parse(request.responseText);
-          
+
           this._disableRowLoaders();
-          
+
           if (typeof responseJSON.results !== 'undefined') {
             if (this.isMounted()) {
               var results = [];
@@ -363,7 +365,7 @@ const GooglePlacesAutocomplete = React.createClass({
               } else {
                 results = responseJSON.results;
               }
-              
+
               this.setState({
                 dataSource: this.state.dataSource.cloneWithRows(this.buildRowsFromResults(results)),
               });
@@ -376,7 +378,7 @@ const GooglePlacesAutocomplete = React.createClass({
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
         }
       };
-      
+
       let url = '';
       if (this.props.nearbyPlacesAPI === 'GoogleReverseGeocoding') {
         // your key must be allowed to use Google Maps Geocoding API
@@ -392,7 +394,7 @@ const GooglePlacesAutocomplete = React.createClass({
           ...this.props.GooglePlacesSearchQuery,
         });
       }
-      
+
       request.open('GET', url);
       request.send();
     } else {
@@ -403,9 +405,9 @@ const GooglePlacesAutocomplete = React.createClass({
     }
   },
 
-  
-  
-  
+
+
+
   _request(text) {
     this._abortRequests();
     if (text.length >= this.props.minLength) {
@@ -450,7 +452,7 @@ const GooglePlacesAutocomplete = React.createClass({
       listViewDisplayed: true,
     });
   },
-  
+
   _getRowLoader() {
     if (Platform.OS === 'android') {
       return (
@@ -467,7 +469,7 @@ const GooglePlacesAutocomplete = React.createClass({
       />
     );
   },
-  
+
   _renderLoader(rowData) {
     if (rowData.isLoading === true) {
       return (
@@ -475,15 +477,15 @@ const GooglePlacesAutocomplete = React.createClass({
           style={[defaultStyles.loader, this.props.styles.loader]}
         >
           {this._getRowLoader()}
-        </View>      
-      );      
+        </View>
+      );
     }
     return null;
   },
 
   _renderRow(rowData = {}) {
     rowData.description = rowData.description || rowData.formatted_address || rowData.name;
-    
+
     return (
       <TouchableHighlight
         onPress={() =>


### PR DESCRIPTION
By adding this prop, I removed the react-native warning: “In the next
release empty section headers will be rendered. In this release you can
use ‘enableEmptySections’ flag to render empty section headers”.