### PR TITLE
Update to work with react-native > 0.24

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -1,7 +1,6 @@
-const React = require('react');
-const ReactNative = require('react-native');
-const {TextInput, View, ListView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicatorIOS, ProgressBarAndroid, PixelRatio} = ReactNative;
-const Qs = require('qs');
+import React, { PropTypes } from 'react';
+import { TextInput, View, ListView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicatorIOS, ProgressBarAndroid, PixelRatio } from 'react-native';
+import Qs from 'qs';
 
 const defaultStyles = {
   container: {


### PR DESCRIPTION
As of [RN v0.26](https://github.com/facebook/react-native/releases/tag/v0.26.0) `PropTypes` is now strictly part of `react` instead of `react-native`.  Without importing it directly, I get undefined calls to `PropTypes` on RN v0.28.