### PR TITLE
replaced encodeURI with encodeURIComponent 

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -439,7 +439,7 @@ const GooglePlacesAutocomplete = React.createClass({
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
         }
       };
-      request.open('GET', 'https://maps.googleapis.com/maps/api/place/autocomplete/json?&input=' + encodeURI(text) + '&' + Qs.stringify(this.props.query));
+      request.open('GET', 'https://maps.googleapis.com/maps/api/place/autocomplete/json?&input=' + encodeURIComponent(text) + '&' + Qs.stringify(this.props.query));
       request.send();
     } else {
       this._results = [];


### PR DESCRIPTION
Hi,

If you use a hash # in your query then it breaks the input. encodeURI() doesn't encode special characters: , / ? : @ & = + $ #. There is an alternative encodeURIComponent() which also encodes those ones.
