### PR TITLE
update package.json with react-native peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "eslint": "^1.9.0",
     "eslint-config-airbnb": "^1.0.0",
     "eslint-plugin-react": "^3.9.0"
+  },
+  "peerDependencies": {
+    "react-native": ">= 0.28"
   }
 }


### PR DESCRIPTION
Added react-native in `peerDependencies`, it just produces an useful warning.
Use of `ActivityIndicator` in Android on previous versions of React Native (< 0.28) causes a crash which is not so easy to track.