### PR TITLE
Scrollable row for long items & use renderSeparator

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -2,6 +2,8 @@ import React, { PropTypes } from 'react';
 import { TextInput, View, ListView, ScrollView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicator, ProgressBarAndroid, PixelRatio } from 'react-native';
 import Qs from 'qs';
 
+const WINDOW = Dimensions.get('window');
+
 const defaultStyles = {
   container: {
     flex: 1,
@@ -493,11 +495,13 @@ const GooglePlacesAutocomplete = React.createClass({
 
     return (
       <ScrollView
+        style={{ flex: 1 }}
         keyboardShouldPersistTaps={true}
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}>
         <TouchableHighlight
+          style={{ minWidth: WINDOW.width }}
           onPress={() =>
             this._onPress(rowData)
           }

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { TextInput, View, ListView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicator, ProgressBarAndroid, PixelRatio } from 'react-native';
+import { TextInput, View, ListView, ScrollView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicator, ProgressBarAndroid, PixelRatio } from 'react-native';
 import Qs from 'qs';
 
 const defaultStyles = {
@@ -488,17 +488,21 @@ const GooglePlacesAutocomplete = React.createClass({
     return null;
   },
 
-  _renderRow(rowData = {}) {
+  _renderRow(rowData = {}, sectionID, rowID) {
     rowData.description = rowData.description || rowData.formatted_address || rowData.name;
 
     return (
-      <TouchableHighlight
-        onPress={() =>
-          this._onPress(rowData)
-        }
-        underlayColor="#c8c7cc"
-      >
-        <View>
+      <ScrollView
+        keyboardShouldPersistTaps={true}
+        horizontal={true}
+        showsHorizontalScrollIndicator={false}
+        showsVerticalScrollIndicator={false}>
+        <TouchableHighlight
+          onPress={() =>
+            this._onPress(rowData)
+          }
+          underlayColor="#c8c7cc"
+        >
           <View style={[defaultStyles.row, this.props.styles.row, rowData.isPredefinedPlace ? this.props.styles.specialItemRow : {}]}>
             <Text
               style={[{flex: 1}, defaultStyles.description, this.props.styles.description, rowData.isPredefinedPlace ? this.props.styles.predefinedPlacesDescription : {}]}
@@ -508,9 +512,16 @@ const GooglePlacesAutocomplete = React.createClass({
             </Text>
             {this._renderLoader(rowData)}
           </View>
-          <View style={[defaultStyles.separator, this.props.styles.separator]} />
-        </View>
-      </TouchableHighlight>
+        </TouchableHighlight>
+      </ScrollView>
+    );
+  },
+
+  _renderSeparator(sectionID, rowID) {
+    return (
+      <View
+        key={ `${sectionID}-${rowID}` }
+        style={[defaultStyles.separator, this.props.styles.separator]} />
     );
   },
 
@@ -532,6 +543,7 @@ const GooglePlacesAutocomplete = React.createClass({
           style={[defaultStyles.listView, this.props.styles.listView]}
           dataSource={this.state.dataSource}
           renderRow={this._renderRow}
+          renderSeparator={this._renderSeparator}
           automaticallyAdjustContentInsets={false}
 
           {...this.props}


### PR DESCRIPTION
I just change the row, to allow them to be scrollable, because sometimes you got long addresses, in the result and you can't really choose the right one because the Text is cut.
I also move the separator view in the `renderSeparator` function of the ListView.