### PR TITLE
Using ActivityIndicator instead of deprecated ActivityIndicatorIOS

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { TextInput, View, ListView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicator, ProgressBarAndroid, PixelRatio } from 'react-native';
+import { TextInput, View, ListView, Image, Text, Dimensions, TouchableHighlight, TouchableWithoutFeedback, Platform, ActivityIndicator, PixelRatio } from 'react-native';
 import Qs from 'qs';
 
 const defaultStyles = {
@@ -459,14 +459,6 @@ const GooglePlacesAutocomplete = React.createClass({
   },
 
   _getRowLoader() {
-    if (Platform.OS === 'android') {
-      return (
-        <ProgressBarAndroid
-          style={[defaultStyles.androidLoader, this.props.styles.androidLoader]}
-          styleAttr="Inverse"
-        />
-      );
-    }
     return (
       <ActivityIndicator
         animating={true}


### PR DESCRIPTION
Use `ActivityIndicator `only otherwise following warnings occur
`Warning: You are manually calling a React.PropTypes validation function for theindeterminateprop onProgressBarAndroid. This is deprecated and will not work in the next major version. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.`