### PR TITLE
Children

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -608,6 +608,7 @@ const GooglePlacesAutocomplete = React.createClass({
           />
         </View>
         {this._getListView()}
+        {this.props.children}
       </View>
     );
   },

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Customizable Google Places autocomplete component for iOS and Android React-Native apps
 
 ### Changelog
+- 1.2.7 : Use `children` prop to pass children elements directly into `GooglePlacesAutocomplete`.
 - 1.2.6 : Added `renderRow` prop.
 - 1.2.5 : Added `renderDescription` prop for rendering dropdown item text
 - 1.2.4 : Added `listViewDisplayed` prop for controlling dropdown

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-google-places-autocomplete",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Customizable Google Places autocomplete component for iOS and Android React-Native apps",
   "main": "GooglePlacesAutocomplete.js",
   "scripts": {


### PR DESCRIPTION
Use `children` prop to pass children elements directly into `GooglePlacesAutocomplete`