### PR TITLE
add keyboardShouldPersistTaps to props, default to „always“

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -104,6 +104,7 @@ const GooglePlacesAutocomplete = React.createClass({
       fetchDetails: false,
       autoFocus: false,
       autoFillOnNotFound: false,
+      keyboardShouldPersistTaps: 'always',
       getDefaultValue: () => '',
       timeout: 20000,
       onTimeout: () => console.warn('google places autocomplete: request timeout'),
@@ -545,7 +546,7 @@ const GooglePlacesAutocomplete = React.createClass({
     return (
       <ScrollView
         style={{ flex: 1 }}
-        keyboardShouldPersistTaps={true}
+        keyboardShouldPersistTaps={this.props.keyboardShouldPersistTaps}
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}>


### PR DESCRIPTION
![bildschirmfoto 2017-01-19 um 10 56 04](https://cloud.githubusercontent.com/assets/570544/22102444/c6e20116-de37-11e6-8ff0-8e5d0ca8143d.png)

as `keyboardShouldPersistTaps={true}"` gives deprecation warning I added this to props and made it default to `"always"`