### PR TITLE
Add ability to change the underlay color of the result list

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -110,6 +110,7 @@ const GooglePlacesAutocomplete = React.createClass({
     renderRow: React.PropTypes.func,
     renderLeftButton: React.PropTypes.func,
     renderRightButton: React.PropTypes.func,
+    listUnderlayColor: React.PropTypes.string
   },
 
   getDefaultProps() {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -597,7 +597,7 @@ const GooglePlacesAutocomplete = React.createClass({
         <TouchableHighlight
           style={{ minWidth: WINDOW.width }}
           onPress={() => this._onPress(rowData)}
-          underlayColor="#c8c7cc"
+          underlayColor={this.props.listUnderlayColor || "#c8c7cc"}
         >
           <View style={[defaultStyles.row, this.props.styles.row, rowData.isPredefinedPlace ? this.props.styles.specialItemRow : {}]}>
             {this._renderRowData(rowData)}


### PR DESCRIPTION
Thanks for the amazing package, It is working perfectly but I think there is minor improvment need to be incorporated. While implementing I realize that you have specified a particular underlay color for the result list rows. It's better to make it dynamic so in this pull request I have added provision to pass underlay color  as a prop named **listUnderlayColor** and if user does not provide this prop then by default underlay color ("#c8c7cc") will get applied.

Let me know if any queries.