### PR TITLE
Setted default types to all

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -137,7 +137,6 @@ const GooglePlacesAutocomplete = React.createClass({
       query: {
         key: 'missing api key',
         language: 'en',
-        types: 'geocode',
       },
       GoogleReverseGeocodingQuery: {},
       GooglePlacesSearchQuery: {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var Example = React.createClass({
           // available options: https://developers.google.com/places/web-service/autocomplete
           key: 'YOUR API KEY',
           language: 'en', // language of the results
-          types: '(cities)', // default: 'geocode'
+          types: '(cities)', // default: all
         }}
         styles={{
           description: {


### PR DESCRIPTION
Hello!

According to the [google api](https://developers.google.com/places/web-service/autocomplete):
> The types of place results to return. See Place Types below. If no type is specified, all types will be returned.

This pr removes the `'geocode'` in default *query* to enable the *all types*.

Cheers.