### PR TITLE
Add feature for changing keyboard return key type

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -84,6 +84,7 @@ const GooglePlacesAutocomplete = React.createClass({
     placeholder: React.PropTypes.string,
     placeholderTextColor: React.PropTypes.string,
     underlineColorAndroid: React.PropTypes.string,
+    returnKeyType: React.PropTypes.string,
     onPress: React.PropTypes.func,
     onNotFound: React.PropTypes.func,
     onFail: React.PropTypes.func,
@@ -123,6 +124,7 @@ const GooglePlacesAutocomplete = React.createClass({
       placeholderTextColor: '#A8A8A8',
       isRowScrollable: true,
       underlineColorAndroid: 'transparent',
+      returnKeyType: 'default',
       onPress: () => {},
       onNotFound: () => {},
       onFail: () => {},
@@ -740,11 +742,13 @@ const GooglePlacesAutocomplete = React.createClass({
           <TextInput
             { ...userProps }
             ref="textInput"
+            returnKeyType={this.props.returnKeyType}
             autoFocus={this.props.autoFocus}
             style={[defaultStyles.textInput, this.props.styles.textInput]}
             onChangeText={this._handleChangeText}
             value={this.state.text}
             placeholder={this.props.placeholder}
+
             placeholderTextColor={this.props.placeholderTextColor}
             onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
             clearButtonMode="while-editing"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ var Example = React.createClass({
         placeholder='Search'
         minLength={2} // minimum length of text to search
         autoFocus={false}
+        returnKeyType={'search'} // Can be left out for default return key https://facebook.github.io/react-native/docs/textinput.html#returnkeytype
         listViewDisplayed='auto'    // true/false/undefined
         fetchDetails={true}
         renderDescription={(row) => row.description} // custom description render
@@ -118,6 +119,7 @@ var Example = React.createClass({
   placeholder='Enter Location'
   minLength={2}
   autoFocus={false}
+  returnKeyType={'default'}
   fetchDetails={true}
   styles={{
     textInputContainer: {


### PR DESCRIPTION
I added this so we're able to change the keyboard return key type to something other than the default. There is a list of types here: https://facebook.github.io/react-native/docs/textinput.html#returnkeytype

To use, you'd simply add the returnKeyType to the props like so: `returnKeyType={'search'}`