### PR TITLE
Fixed default value not loading when the view is rendered

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -217,6 +217,10 @@ const GooglePlacesAutocomplete = React.createClass({
       : this._request;
   },
 
+  componentDidMount() {
+    this._onChangeText(this.state.text);
+  },
+
   componentWillReceiveProps(nextProps) {
     if (nextProps.listViewDisplayed !== 'auto') {
       this.setState({

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -162,14 +162,14 @@ export default class GooglePlacesAutocomplete extends Component {
     this._request = this.props.debounce
       ? debounce(this._request, this.props.debounce)
       : this._request;
-  },
+  }
 
   componentDidMount() {
     // This will load the default value's search results after the view has
     // been rendered
     this._isMounted = true;
     this._onChangeText(this.state.text);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.listViewDisplayed !== 'auto') {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -218,6 +218,8 @@ const GooglePlacesAutocomplete = React.createClass({
   },
 
   componentDidMount() {
+    // This will load the default value's search results after the view has
+    // been rendered
     this._onChangeText(this.state.text);
   },
 


### PR DESCRIPTION
When specifying a default value as a property, the results of this value aren't loaded. This means that the user has to make a change for the search results of the default value to appear. Having a default seems pointless since the user still has to modify it to see the search results.

I've fixed this by calling `_onChangeText` after the view is rendered. Now when the view is rendered the results for the default value are displayed.