### PR TITLE
Fixed search results disappearing off screen

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -620,7 +620,7 @@ const GooglePlacesAutocomplete = React.createClass({
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}>
         <TouchableHighlight
-          style={{ minWidth: WINDOW.width }}
+          style={{ width: WINDOW.width }}
           onPress={() => this._onPress(rowData)}
           underlayColor={this.props.listUnderlayColor || "#c8c7cc"}
         >


### PR DESCRIPTION
Results that don't fit within the screen width would continue off the screen, however using `width` instead of `minWidth` for the `TouchableHighlight` style will show an ellipsis when running out of room. This is more user friendly.