### PR TITLE
adding origin property update

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -384,6 +384,9 @@ const GooglePlacesAutocomplete = React.createClass({
         placeid: rowData.place_id,
         language: this.props.query.language,
       }));
+      if (this.props.query.origin !== null) {
+         request.setRequestHeader('Referer', this.props.query.origin)
+      }
       request.send();
     } else if (rowData.isCurrentLocation === true) {
 
@@ -503,6 +506,9 @@ const GooglePlacesAutocomplete = React.createClass({
       }
 
       request.open('GET', url);
+      if (this.props.query.origin !== null) {
+         request.setRequestHeader('Referer', this.props.query.origin)
+      }
       request.send();
     } else {
       this._results = [];
@@ -541,6 +547,9 @@ const GooglePlacesAutocomplete = React.createClass({
         }
       };
       request.open('GET', 'https://maps.googleapis.com/maps/api/place/autocomplete/json?&input=' + encodeURIComponent(text) + '&' + Qs.stringify(this.props.query));
+      if (this.props.query.origin !== null) {
+         request.setRequestHeader('Referer', this.props.query.origin)
+      }
       request.send();
     } else {
       this._results = [];


### PR DESCRIPTION
Added Referer request header as prop for the google-places-autocomplete component. This update allows for a restricted Google API key as seen in this issue:

https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/140