### PR TITLE
Add activity indicator when searching for places

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -671,12 +671,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
   _getFlatList() {
     if (this.state.loading) {
-      return (
-        <ActivityIndicator
-          style={{paddingTop:10}}
-          animating={true}
-        />
-      );
+      return this.props.loadingComponent;
     }
 
     if ((this.state.text !== '' || this.props.predefinedPlaces.length || this.props.currentLocation === true) && this.state.listViewDisplayed === true) {
@@ -733,6 +728,16 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 }
 
+// Loading screen used while searching current text input
+function getDefaultLoadingScreen() {
+  return (
+    <ActivityIndicator
+      style={{paddingTop:10}}
+      animating={true}
+    />
+  );
+}
+
 GooglePlacesAutocomplete.propTypes = {
   placeholder: PropTypes.string,
   placeholderTextColor: PropTypes.string,
@@ -768,7 +773,8 @@ GooglePlacesAutocomplete.propTypes = {
   renderRightButton: PropTypes.func,
   listUnderlayColor: PropTypes.string,
   debounce: PropTypes.number,
-  isRowScrollable: PropTypes.bool
+  isRowScrollable: PropTypes.bool,
+  loadingComponent: PropTypes.element
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -809,7 +815,8 @@ GooglePlacesAutocomplete.defaultProps = {
   predefinedPlacesAlwaysVisible: false,
   enableEmptySections: true,
   listViewDisplayed: 'auto',
-  debounce: 0
+  debounce: 0,
+  loadingComponent: getDefaultLoadingScreen()
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -406,6 +406,9 @@ export default class GooglePlacesAutocomplete extends Component {
         if (request.readyState !== 4) {
           return;
         }
+        this.setState({
+          loading: false
+        });
         if (request.status === 200) {
           const responseJSON = JSON.parse(request.responseText);
 
@@ -453,6 +456,9 @@ export default class GooglePlacesAutocomplete extends Component {
       if (this.props.query.origin !== null) {
          request.setRequestHeader('Referer', this.props.query.origin)
       }
+      this.setState({
+        loading: true
+      });
       request.send();
     } else {
       this._results = [];
@@ -473,6 +479,9 @@ export default class GooglePlacesAutocomplete extends Component {
         if (request.readyState !== 4) {
           return;
         }
+        this.setState({
+          loading: false
+        });
         if (request.status === 200) {
           const responseJSON = JSON.parse(request.responseText);
           if (typeof responseJSON.predictions !== 'undefined') {
@@ -494,6 +503,9 @@ export default class GooglePlacesAutocomplete extends Component {
       if (this.props.query.origin !== null) {
          request.setRequestHeader('Referer', this.props.query.origin)
       }
+      this.setState({
+        loading: true
+      });
       request.send();
     } else {
       this._results = [];
@@ -658,6 +670,15 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   _getFlatList() {
+    if (this.state.loading) {
+      return (
+        <ActivityIndicator
+          style={{paddingTop:10}}
+          animating={true}
+        />
+      );
+    }
+
     if ((this.state.text !== '' || this.props.predefinedPlaces.length || this.props.currentLocation === true) && this.state.listViewDisplayed === true) {
       return (
         <FlatList


### PR DESCRIPTION
This adds an ActivityIndicator displayed while the component searching for the latest query in the search bar. This avoids confusion on slow connections when a user inputs a location and there's no feedback.