### PR TITLE
Fix warning: Each child in an array or iterator should have a unique "key" prop

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -140,6 +140,7 @@ export default class GooglePlacesAutocomplete extends Component {
       res = [...this.props.predefinedPlaces];
       if (this.props.currentLocation === true) {
         res.unshift({
+          id: 'currentLocationID',
           description: this.props.currentLocationLabel,
           isCurrentLocation: true,
         });
@@ -218,6 +219,7 @@ export default class GooglePlacesAutocomplete extends Component {
       (position) => {
         if (this.props.nearbyPlacesAPI === 'None') {
           let currentLocation = {
+            id: 'currentLocationID',
             description: this.props.currentLocationLabel,
             geometry: {
               location: {
@@ -654,7 +656,7 @@ export default class GooglePlacesAutocomplete extends Component {
         <FlatList
           style={[defaultStyles.listView, this.props.styles.listView]}
           data={this.state.dataSource}
-          keyExtractor={(item) => item.description}
+          keyExtractor={(item) => item.id}
           extraData={[this.state.dataSource, this.props]}
           ItemSeparatorComponent={this._renderSeparator}
           renderItem={({ item }) => this._renderRow(item)}


### PR DESCRIPTION
This warning appear only if currentLocation is enabled, and after you tap on it the warning is displayed:

![dhwfg9jxkae41oy](https://user-images.githubusercontent.com/314122/29670751-0f63f990-88be-11e7-94d0-e3df733955c5.jpg)

So, the solution was to use the `id` instead of the `description` in the `keyExtractor`. And also applied a fixed id for the Current location row.

@esganzerla we already discussed a bit about this problem. I've tested it and it's working properly now. Please take a look at your earliest convenience and let me know if I should change something else. Thanks!