### PR TITLE
Only Show Loading Component if Set

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -683,7 +683,7 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   _getFlatList() {
-    if (this.state.loading) {
+    if (this.state.loading && this.props.loadingComponent) {
       return this.props.loadingComponent;
     }
 


### PR DESCRIPTION
Only display the loading component if not set to `null` so that the results list can persist between searches if the loading component isn't desired. Without this, the results list will flash since it alternates between the FlatList and nothing if the prop is set to `null`