### PR TITLE
Default current location search to low accuracy

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -173,7 +173,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
   getCurrentLocation = () => {
     let options = {
-      enableHighAccuracy: true,
+      enableHighAccuracy: false,
       timeout: 20000,
       maximumAge: 1000
     };


### PR DESCRIPTION
I was having issues with the current location requests timing out on android. I switched the default highAccuracyLocation to false and this solved my issue.

[This is a related issue](https://github.com/facebook/react-native/issues/7495)

[Here is a sample repository showing the working change.](https://github.com/jmpridgen/google-places-autocomplete-sample)