### PR TITLE
added onblur after initialization

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -129,6 +129,7 @@ export default class GooglePlacesAutocomplete extends Component {
     // been rendered
     this._isMounted = true;
     this._onChangeText(this.state.text);
+    this._onBlur()
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
This solves #235 where the autocomplete box opens on a defaultValue.  This blurs immediately on mount so the autocomplete box is hidden if there's a default value.