### PR TITLE
open the list on default value if the item is auto-focused

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -494,7 +494,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
     this.setState({
       text: text,
-      listViewDisplayed: this._isMounted,
+      listViewDisplayed: this._isMounted || this.props.autoFocus,
     });
   }
 


### PR DESCRIPTION
In my previous PR I fixed a bug where if default value was set, the list would show open. In this minor PR I attempt to maintain a more sensible functionality - if the component is autoFocus=true, we will show the list. Otherwise we won't.