### PR TITLE
Fixes the resizeMode of the image

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -615,7 +615,7 @@ export default class GooglePlacesAutocomplete extends Component {
       >
         <Image
           style={[this.props.suppressDefaultStyles ? {} : defaultStyles.powered, this.props.styles.powered]}
-          resizeMode={Image.resizeMode.contain}
+          resizeMode={'contain'}
           source={require('./images/powered_by_google_on_white.png')}
         />
       </View>


### PR DESCRIPTION
This MR fixes the crash when started searching the location.

Can close https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/319 , https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/317 and all the similar issues