### PR TITLE
Clear button added

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -10,12 +10,14 @@ import {
   StyleSheet,
   Dimensions,
   TouchableHighlight,
+  TouchableOpacity
   Platform,
   ActivityIndicator,
   PixelRatio
 } from 'react-native';
 import Qs from 'qs';
 import debounce from 'lodash.debounce';
+import Icon from 'react-native-vector-icons/FontAwesome';
 
 const WINDOW = Dimensions.get('window');
 
@@ -71,6 +73,11 @@ const defaultStyles = {
   androidLoader: {
     marginRight: -15,
   },
+  clearButton:{
+    backgroundColor: 'rgba(0,0,0,0)',
+    justifyContent: 'center',
+    paddingRight: WINDOW.width / 30
+  }
 };
 
 export default class GooglePlacesAutocomplete extends Component {
@@ -703,6 +710,18 @@ export default class GooglePlacesAutocomplete extends Component {
               { ...userProps }
               onChangeText={this._handleChangeText}
             />
+			<TouchableOpacity
+				style={defaultStyles.clearButton}
+				onPress={() => {
+					this.setState({ text: '' });
+				}}
+			>
+				<Icon
+					name="remove"
+					size={15}
+					style={{ color: 'black' }}
+				/>
+			</TouchableOpacity>
             {this._renderRightButton()}
           </View>
         }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.10",
+    "react-native-vector-icons": "^4.6.0",
     "qs": "^5.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Added a clear button implementation that would work for both android and ios and therefore not relying on the TextInput's `clearButtonMode` option.