### PR TITLE
change clearButtonMode prop

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -683,6 +683,7 @@ export default class GooglePlacesAutocomplete extends Component {
   render() {
     let {
       onFocus,
+      clearButtonMode,
       ...userProps
     } = this.props.textInputProps;
     return (
@@ -706,8 +707,10 @@ export default class GooglePlacesAutocomplete extends Component {
               onSubmitEditing={this.props.onSubmitEditing}
               placeholderTextColor={this.props.placeholderTextColor}
               onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
-              clearButtonMode="while-editing"
               underlineColorAndroid={this.props.underlineColorAndroid}
+              clearButtonMode={
+                clearButtonMode ? clearButtonMode : "while-editing"
+              }
               { ...userProps }
               onChangeText={this._handleChangeText}
             />


### PR DESCRIPTION
## Current

```
<TextInput
  ...
  clearButtonMode="while-editing"
  underlineColorAndroid={this.props.underlineColorAndroid}
  { ...userProps }
  onChangeText={this._handleChangeText}
/>
```

## Should be changed like this

```
const {
  ...
  clearButtonMode,
  ...
} = this.props.textInputProps;

<TextInput
  ...
  clearButtonMode={
    clearButtonMode ? clearButtonMode : "while-editing"
  }
  underlineColorAndroid={this.props.underlineColorAndroid}
  { ...userProps }
  onChangeText={this._handleChangeText}
/>
```

## Usage

```
<GooglePlacesAutocomplete
  ...
  textInputProps={{ clearButtonMode: "never" }}
/>
```

## Ref Issue
- #356 