### PR TITLE
Remove onBlur form TextInput

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -605,8 +605,9 @@ export default class GooglePlacesAutocomplete extends Component {
   _onBlur = () => {
     this.triggerBlur();
 
-    if (this.props && this.props.onBlur) {
-      this.props.onBlur();
+    if (this.props && this.props.textInputProps
+      && this.props.textInputProps.onBlur) {
+      this.props.textInputProps.onBlur();
     }
 
     this.setState({
@@ -615,8 +616,9 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   _onFocus = () => {
-    if (this.props && this.props.onFocus) {
-      this.props.onFocus();
+    if (this.props && this.props.textInputProps
+       && this.props.textInputProps.onFocus) {
+      this.props.textInputProps.onFocus();
     }
 
     this.setState({ listViewDisplayed: true });
@@ -692,9 +694,7 @@ export default class GooglePlacesAutocomplete extends Component {
   }
   render() {
     let {
-      onFocus,
       clearButtonMode,
-      ...userProps
     } = this.props.textInputProps;
     return (
       <View
@@ -716,12 +716,11 @@ export default class GooglePlacesAutocomplete extends Component {
               placeholder={this.props.placeholder}
               onSubmitEditing={this.props.onSubmitEditing}
               placeholderTextColor={this.props.placeholderTextColor}
-              onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
+              onFocus={this._onFocus}
               clearButtonMode={
                 clearButtonMode ? clearButtonMode : "while-editing"
               }
               underlineColorAndroid={this.props.underlineColorAndroid}
-              { ...userProps }
               onChangeText={this._handleChangeText}
             />
             {this._renderRightButton()}

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -241,7 +241,7 @@ export default class GooglePlacesAutocomplete extends Component {
             if (this._isMounted === true) {
               const details = responseJSON.result;
               this._disableRowLoaders();
-              this._onBlur();
+
 
               this.setState({
                 text: this._renderDescription( rowData ),
@@ -249,6 +249,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
               delete rowData.isLoading;
               this.props.onPress(rowData, details);
+              this._onBlur();
             }
           } else {
             this._disableRowLoaders();
@@ -274,7 +275,7 @@ export default class GooglePlacesAutocomplete extends Component {
               'google places autocomplete: request could not be completed or has been aborted'
             );
           } else {
-            this.props.onFail('request could not be completed or has been aborted');
+            this.props.onFail();
           }
         }
       };
@@ -307,12 +308,14 @@ export default class GooglePlacesAutocomplete extends Component {
         text: this._renderDescription( rowData ),
       });
 
-      this._onBlur();
+
       delete rowData.isLoading;
       let predefinedPlace = this._getPredefinedPlace(rowData);
 
       // sending predefinedPlace as details for predefined places
       this.props.onPress(predefinedPlace, predefinedPlace);
+
+      this._onBlur();
     }
   }
 
@@ -411,11 +414,7 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-              if(!this.props.onFail)
-                console.warn('google places autocomplete: ' + responseJSON.error_message);
-              else{
-                this.props.onFail(responseJSON.error_message)
-              }
+            console.warn('google places autocomplete: ' + responseJSON.error_message);
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
@@ -479,11 +478,7 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-            if(!this.props.onFail)
-              console.warn('google places autocomplete: ' + responseJSON.error_message);
-            else{
-              this.props.onFail(responseJSON.error_message)
-            }
+            console.warn('google places autocomplete: ' + responseJSON.error_message);
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
@@ -605,12 +600,22 @@ export default class GooglePlacesAutocomplete extends Component {
   _onBlur = () => {
     this.triggerBlur();
 
+    if (this.props && this.props.onBlur) {
+      this.props.onBlur();
+    }
+
     this.setState({
       listViewDisplayed: false
     });
   }
 
-  _onFocus = () => this.setState({ listViewDisplayed: true })
+  _onFocus = () => {
+    if (this.props && this.props.onFocus) {
+      this.props.onFocus();
+    }
+
+    this.setState({ listViewDisplayed: true });
+  }
 
   _renderPoweredLogo = () => {
     if (!this._shouldShowPoweredLogo()) {
@@ -683,7 +688,6 @@ export default class GooglePlacesAutocomplete extends Component {
   render() {
     let {
       onFocus,
-      clearButtonMode,
       ...userProps
     } = this.props.textInputProps;
     return (
@@ -707,11 +711,8 @@ export default class GooglePlacesAutocomplete extends Component {
               onSubmitEditing={this.props.onSubmitEditing}
               placeholderTextColor={this.props.placeholderTextColor}
               onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
-              onBlur={this._onBlur}
+              clearButtonMode="while-editing"
               underlineColorAndroid={this.props.underlineColorAndroid}
-              clearButtonMode={
-                clearButtonMode ? clearButtonMode : "while-editing"
-              }
               { ...userProps }
               onChangeText={this._handleChangeText}
             />

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -241,7 +241,7 @@ export default class GooglePlacesAutocomplete extends Component {
             if (this._isMounted === true) {
               const details = responseJSON.result;
               this._disableRowLoaders();
-
+              this._onBlur();
 
               this.setState({
                 text: this._renderDescription( rowData ),
@@ -249,7 +249,6 @@ export default class GooglePlacesAutocomplete extends Component {
 
               delete rowData.isLoading;
               this.props.onPress(rowData, details);
-              this._onBlur();
             }
           } else {
             this._disableRowLoaders();
@@ -275,7 +274,7 @@ export default class GooglePlacesAutocomplete extends Component {
               'google places autocomplete: request could not be completed or has been aborted'
             );
           } else {
-            this.props.onFail();
+            this.props.onFail('request could not be completed or has been aborted');
           }
         }
       };
@@ -308,14 +307,12 @@ export default class GooglePlacesAutocomplete extends Component {
         text: this._renderDescription( rowData ),
       });
 
-
+      this._onBlur();
       delete rowData.isLoading;
       let predefinedPlace = this._getPredefinedPlace(rowData);
 
       // sending predefinedPlace as details for predefined places
       this.props.onPress(predefinedPlace, predefinedPlace);
-
-      this._onBlur();
     }
   }
 
@@ -414,7 +411,11 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-            console.warn('google places autocomplete: ' + responseJSON.error_message);
+            if (!this.props.onFail) {
+              console.warn('google places autocomplete: ' + responseJSON.error_message);
+            } else {
+              this.props.onFail(responseJSON.error_message)
+            }
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
@@ -478,7 +479,11 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-            console.warn('google places autocomplete: ' + responseJSON.error_message);
+            if(!this.props.onFail) {
+              console.warn('google places autocomplete: ' + responseJSON.error_message);
+            } else {
+              this.props.onFail(responseJSON.error_message)
+            }
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
@@ -688,6 +693,7 @@ export default class GooglePlacesAutocomplete extends Component {
   render() {
     let {
       onFocus,
+      clearButtonMode,
       ...userProps
     } = this.props.textInputProps;
     return (
@@ -711,7 +717,9 @@ export default class GooglePlacesAutocomplete extends Component {
               onSubmitEditing={this.props.onSubmitEditing}
               placeholderTextColor={this.props.placeholderTextColor}
               onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
-              clearButtonMode="while-editing"
+              clearButtonMode={
+                clearButtonMode ? clearButtonMode : "while-editing"
+              }
               underlineColorAndroid={this.props.underlineColorAndroid}
               { ...userProps }
               onChangeText={this._handleChangeText}


### PR DESCRIPTION
I have a problem in my project: if I create onFocus and onBlur props to component, and in this props I try to use setState. Here is exapmle:

```
<GooglePlacesAutocomplete
    ...
    textInputProps={{
      onFocus: this.handleFocus,
      onBlur: this.handleBlur,
    }}
    ...
/>
```
`handleFocus = () => {
    this.setState({
      city: '',
      isSearching: true,
    });
  };`
`handleBlur = () => {
    this.setState({
      isSearching: false,
    });
  };
`

And in this case when I try to select item form dropdown, onBlur call on textInput and rerenders close the dropdownlist. I cant select any row. 

I remove onBlur from TextInput, and add props to it to `_onBlur` method. 
And in this case all works fine.