### PR TITLE
Add possibility to specify options for the googlePlacesDetails query 

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -283,6 +283,7 @@ export default class GooglePlacesAutocomplete extends Component {
         key: this.props.query.key,
         placeid: rowData.place_id,
         language: this.props.query.language,
+        ...this.props.GooglePlacesDetailsQuery,
       }));
 
       if (this.props.query.origin !== null) {
@@ -743,6 +744,7 @@ GooglePlacesAutocomplete.propTypes = {
   query: PropTypes.object,
   GoogleReverseGeocodingQuery: PropTypes.object,
   GooglePlacesSearchQuery: PropTypes.object,
+  GooglePlacesDetailsQuery: PropTypes.object,
   styles: PropTypes.object,
   textInputProps: PropTypes.object,
   enablePoweredByContainer: PropTypes.bool,
@@ -791,6 +793,7 @@ GooglePlacesAutocomplete.defaultProps = {
     types: 'geocode',
   },
   GoogleReverseGeocodingQuery: {},
+  GooglePlacesDetailsQuery: {},
   GooglePlacesSearchQuery: {
     rankby: 'distance',
     types: 'food',

--- a/GooglePlacesAutocompleteExample/Example.js
+++ b/GooglePlacesAutocompleteExample/Example.js
@@ -41,7 +41,7 @@ var Example = React.createClass({
             color: '#1faadb',
           },
         }}
-        
+
         currentLocation={true} // Will add a 'Current location' button at the top of the predefined places list
         currentLocationLabel="Current location"
         nearbyPlacesAPI='GooglePlacesSearch' // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
@@ -53,12 +53,15 @@ var Example = React.createClass({
           rankby: 'distance',
           types: 'food',
         }}
-        
-        
+        GooglePlacesDetailsQuery={{
+            // available options for GooglePlacesDetails API : https://developers.google.com/places/web-service/details
+            fields: 'formatted_address',
+        }}
+
         filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities
-        
+
         predefinedPlaces={[homePlace, workPlace]}
-        
+
         predefinedPlacesAlwaysVisible={true}
       />
     );

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ const GooglePlacesInput = () => {
         rankby: 'distance',
         types: 'food'
       }}
+      
+      GooglePlacesDetailsQuery={{
+        // available options for GooglePlacesDetails API : https://developers.google.com/places/web-service/details
+        fields: 'formatted_address',
+      }}
 
       filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities
       predefinedPlaces={[homePlace, workPlace]}


### PR DESCRIPTION
As specified in the google documentation, requiring all props when calling this endpoint `https://maps.googleapis.com/maps/api/place/details/json` will increase the bill. 💵
 
> Warning: If you do not specify at least one field with a request, or if you omit the fields parameter from a request, ALL possible fields will be returned, and you will be billed accordingly. This applies only to Place Details requests (_source_ : https://developers.google.com/places/web-service/details)

This PR add the possibility to specify parameters for this request by adding this : 
```
GooglePlacesDetailsQuery={{
 fields: 'formatted_address'
}}
```
 _Available options for GooglePlacesDetails API : https://developers.google.com/places/web-service/details_