### PR TITLE
Fix parameter for GooglePlacesSearchQuery (types -> type)

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -793,7 +793,7 @@ GooglePlacesAutocomplete.defaultProps = {
   GoogleReverseGeocodingQuery: {},
   GooglePlacesSearchQuery: {
     rankby: 'distance',
-    types: 'food',
+    type: 'food',
   },
   styles: {},
   textInputProps: {},

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -793,7 +793,7 @@ GooglePlacesAutocomplete.defaultProps = {
   GoogleReverseGeocodingQuery: {},
   GooglePlacesSearchQuery: {
     rankby: 'distance',
-    type: 'food',
+    type: 'restaurant'
   },
   styles: {},
   textInputProps: {},

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const GooglePlacesInput = () => {
       GooglePlacesSearchQuery={{
         // available options for GooglePlacesSearch API : https://developers.google.com/places/web-service/search
         rankby: 'distance',
-        type: 'food'
+        type: 'cafe'
       }}
 
       filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ const GooglePlacesInput = () => {
       onPress={(data, details = null) => { // 'details' is provided when fetchDetails = true
         console.log(data, details);
       }}
-      
+
       getDefaultValue={() => ''}
-      
+
       query={{
         // available options: https://developers.google.com/places/web-service/autocomplete
         key: 'YOUR API KEY',
         language: 'en', // language of the results
         types: '(cities)' // default: 'geocode'
       }}
-      
+
       styles={{
         textInputContainer: {
           width: '100%'
@@ -55,7 +55,7 @@ const GooglePlacesInput = () => {
           color: '#1faadb'
         }
       }}
-      
+
       currentLocation={true} // Will add a 'Current location' button at the top of the predefined places list
       currentLocationLabel="Current location"
       nearbyPlacesAPI='GooglePlacesSearch' // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
@@ -65,7 +65,7 @@ const GooglePlacesInput = () => {
       GooglePlacesSearchQuery={{
         // available options for GooglePlacesSearch API : https://developers.google.com/places/web-service/search
         rankby: 'distance',
-        types: 'food'
+        type: 'food'
       }}
 
       filterReverseGeocodingByTypes={['locality', 'administrative_area_level_3']} // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities


### PR DESCRIPTION
This PR fixes the "typo" on the example parameter for GooglePlacesSearchQuery ([#358](https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/358)), following the [Google Places Search Documentation](https://developers.google.com/places/web-service/search)

Old:

```js
GooglePlacesSearchQuery={{
        // available options for GooglePlacesSearch API : https://developers.google.com/places/web-service/search
        rankby: 'distance',
        types: 'food'
      }}
```

New: 
```js
GooglePlacesSearchQuery={{
        // available options for GooglePlacesSearch API : https://developers.google.com/places/web-service/search
        rankby: 'distance',
        type: 'cafe'
      }}
```

I also updated the type, since `food`  was not valid. See doc (place types 1) [here](https://developers.google.com/places/web-service/supported_types)