### PR TITLE
Guard for inputtext set to null

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -458,7 +458,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
   _request = (text) => {
     this._abortRequests();
-    if (text.length >= this.props.minLength) {
+    if (text && text.length >= this.props.minLength) {
       const request = new XMLHttpRequest();
       this._requests.push(request);
       request.timeout = this.props.timeout;

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -87,7 +87,9 @@ export default class GooglePlacesAutocomplete extends Component {
   getInitialState = () => ({
     text: this.props.getDefaultValue(),
     dataSource: this.buildRowsFromResults([]),
+    hasResults: false,
     listViewDisplayed: this.props.listViewDisplayed === 'auto' ? false : this.props.listViewDisplayed,
+    autoSelected: false
   })
 
   setAddressText = address => this.setState({ text: address })
@@ -327,6 +329,7 @@ export default class GooglePlacesAutocomplete extends Component {
         rows[i].isLoading = true;
         this.setState({
           dataSource: rows,
+          hasResults: (rows.length > 0)
         });
         break;
       }
@@ -343,6 +346,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
       this.setState({
         dataSource: this.buildRowsFromResults(this._results),
+        hasResults: (this._results.length > 0)
       });
     }
   }
@@ -411,6 +415,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
               this.setState({
                 dataSource: this.buildRowsFromResults(results),
+                hasResults: (results.length > 0)
               });
             }
           }
@@ -419,10 +424,16 @@ export default class GooglePlacesAutocomplete extends Component {
                 console.warn('google places autocomplete: ' + responseJSON.error_message);
               else{
                 this.props.onFail(responseJSON.error_message)
+                this.setState({
+                  hasResults: false
+                });
               }
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
+          this.setState({
+            hasResults: false
+          });
         }
       };
 
@@ -452,6 +463,7 @@ export default class GooglePlacesAutocomplete extends Component {
       this._results = [];
       this.setState({
         dataSource: this.buildRowsFromResults([]),
+        hasResults: false
       });
     }
   }
@@ -479,6 +491,7 @@ export default class GooglePlacesAutocomplete extends Component {
               this._results = results;
               this.setState({
                 dataSource: this.buildRowsFromResults(results),
+                hasResults: (results.length > 0)
               });
             }
           }
@@ -506,6 +519,7 @@ export default class GooglePlacesAutocomplete extends Component {
       this._results = [];
       this.setState({
         dataSource: this.buildRowsFromResults([]),
+        hasResults: false
       });
     }
   }
@@ -521,6 +535,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
     this.setState({
       text: text,
+      autoSelected: false,
       listViewDisplayed: this._isMounted || this.props.autoFocus,
     });
   }
@@ -618,9 +633,12 @@ export default class GooglePlacesAutocomplete extends Component {
   _onBlur = () => {
     this.triggerBlur();
 
-    this.setState({
-      listViewDisplayed: false
-    });
+    if (!this.state.autoSelected && this.props.autoSelectFirstResult && this.state.hasResults && this.state.dataSource[0]) {
+      this.setState({
+        autoSelected: true,
+        listViewDisplayed: false
+      }, () => this._onPress(this.state.dataSource[0]));
+    }    
   }
 
   _onFocus = () => this.setState({ listViewDisplayed: true })

--- a/GooglePlacesAutocompleteExample/Example.js
+++ b/GooglePlacesAutocompleteExample/Example.js
@@ -63,6 +63,7 @@ var Example = React.createClass({
         predefinedPlaces={[homePlace, workPlace]}
 
         predefinedPlacesAlwaysVisible={true}
+        autoSelectFirstResult={true}
       />
     );
   }

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const GooglePlacesInput = () => {
       debounce={200} // debounce the requests in ms. Set to 0 to remove debounce. By default 0ms.
       renderLeftButton={()  => <Image source={require('path/custom/left-icon')} />}
       renderRightButton={() => <Text>Custom text after the input</Text>}
+      autoSelectFirstResult={true} // On blur, automatically select the first result in the list
     />
   );
 }


### PR DESCRIPTION
If for some reason the input text is set to null (or undefined) rather than an empty string, the computation of minimal length will fail.

This guards against it by testing that the text is not null nor undefined before testing for its length