### PR TITLE
Added options to customize ActivityIndicator

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -72,6 +72,10 @@ const defaultStyles = {
   androidLoader: {
     marginRight: -15,
   },
+  activityIndicator: {
+    size: "small",
+    color: "gray"
+  }
 };
 
 export default class GooglePlacesAutocomplete extends Component {
@@ -79,7 +83,7 @@ export default class GooglePlacesAutocomplete extends Component {
   _results = [];
   _requests = [];
 
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.state = this.getInitialState.call(this);
   }
@@ -138,8 +142,8 @@ export default class GooglePlacesAutocomplete extends Component {
 
     if (typeof (nextProps.text) !== "undefined" && this.state.text !== nextProps.text) {
       this.setState({
-          listViewDisplayed: listViewDisplayed
-        },
+        listViewDisplayed: listViewDisplayed
+      },
         this._handleChangeText(nextProps.text));
     } else {
       this.setState({
@@ -247,7 +251,7 @@ export default class GooglePlacesAutocomplete extends Component {
               this._onBlur();
 
               this.setState({
-                text: this._renderDescription( rowData ),
+                text: this._renderDescription(rowData),
               });
 
               delete rowData.isLoading;
@@ -299,7 +303,7 @@ export default class GooglePlacesAutocomplete extends Component {
       this._enableRowLoader(rowData);
 
       this.setState({
-        text: this._renderDescription( rowData ),
+        text: this._renderDescription(rowData),
       });
 
       this.triggerBlur(); // hide keyboard but not the results
@@ -308,7 +312,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
     } else {
       this.setState({
-        text: this._renderDescription( rowData ),
+        text: this._renderDescription(rowData),
       });
 
       this._onBlur();
@@ -415,11 +419,11 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-              if(!this.props.onFail)
-                console.warn('google places autocomplete: ' + responseJSON.error_message);
-              else{
-                this.props.onFail(responseJSON.error_message)
-              }
+            if (!this.props.onFail)
+              console.warn('google places autocomplete: ' + responseJSON.error_message);
+            else {
+              this.props.onFail(responseJSON.error_message)
+            }
           }
         } else {
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
@@ -444,7 +448,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
       request.open('GET', url);
       if (this.props.query.origin !== null) {
-         request.setRequestHeader('Referer', this.props.query.origin)
+        request.setRequestHeader('Referer', this.props.query.origin)
       }
 
       request.send();
@@ -483,9 +487,9 @@ export default class GooglePlacesAutocomplete extends Component {
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-            if(!this.props.onFail)
+            if (!this.props.onFail)
               console.warn('google places autocomplete: ' + responseJSON.error_message);
-            else{
+            else {
               this.props.onFail(responseJSON.error_message)
             }
           }
@@ -498,7 +502,7 @@ export default class GooglePlacesAutocomplete extends Component {
       }
       request.open('GET', 'https://maps.googleapis.com/maps/api/place/autocomplete/json?&input=' + encodeURIComponent(text) + '&' + Qs.stringify(this.props.query));
       if (this.props.query.origin !== null) {
-         request.setRequestHeader('Referer', this.props.query.origin)
+        request.setRequestHeader('Referer', this.props.query.origin)
       }
 
       request.send();
@@ -509,8 +513,8 @@ export default class GooglePlacesAutocomplete extends Component {
       });
     }
   }
-  
-  clearText(){
+
+  clearText() {
     this.setState({
       text: ""
     })
@@ -541,7 +545,14 @@ export default class GooglePlacesAutocomplete extends Component {
     return (
       <ActivityIndicator
         animating={true}
-        size="small"
+        size={
+          this.props.styles.activityIndicator.size ||
+          defaultStyles.activityIndicator.size
+        }
+        color={
+          this.props.styles.activityIndicator.color ||
+          defaultStyles.activityIndicator.color
+        }
       />
     );
   }
@@ -595,8 +606,9 @@ export default class GooglePlacesAutocomplete extends Component {
           underlayColor={this.props.listUnderlayColor || "#c8c7cc"}
         >
           <View style={[this.props.suppressDefaultStyles ? {} : defaultStyles.row, this.props.styles.row, rowData.isPredefinedPlace ? this.props.styles.specialItemRow : {}]}>
-            {this._renderLoader(rowData)}
+            {!this.props.loaderRight && this._renderLoader(rowData)}
             {this._renderRowData(rowData)}
+            {this.props.loaderRight && this._renderLoader(rowData)}
           </View>
         </TouchableHighlight>
       </ScrollView>
@@ -610,7 +622,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
     return (
       <View
-        key={ `${sectionID}-${rowID}` }
+        key={`${sectionID}-${rowID}`}
         style={[this.props.suppressDefaultStyles ? {} : defaultStyles.separator, this.props.styles.separator]} />
     );
   }
@@ -722,13 +734,13 @@ export default class GooglePlacesAutocomplete extends Component {
               placeholder={this.props.placeholder}
               onSubmitEditing={this.props.onSubmitEditing}
               placeholderTextColor={this.props.placeholderTextColor}
-              onFocus={onFocus ? () => {this._onFocus(); onFocus()} : this._onFocus}
+              onFocus={onFocus ? () => { this._onFocus(); onFocus() } : this._onFocus}
               onBlur={this._onBlur}
               underlineColorAndroid={this.props.underlineColorAndroid}
               clearButtonMode={
                 clearButtonMode ? clearButtonMode : "while-editing"
               }
-              { ...userProps }
+              {...userProps}
               onChangeText={this._handleChangeText}
             />
             {this._renderRightButton()}
@@ -784,7 +796,8 @@ GooglePlacesAutocomplete.propTypes = {
   suppressDefaultStyles: PropTypes.bool,
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  loaderRight: PropTypes.bool
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -793,9 +806,9 @@ GooglePlacesAutocomplete.defaultProps = {
   underlineColorAndroid: 'transparent',
   returnKeyType: 'default',
   keyboardAppearance: 'default',
-  onPress: () => {},
-  onNotFound: () => {},
-  onFail: () => {},
+  onPress: () => { },
+  onNotFound: () => { },
+  onFail: () => { },
   minLength: 0,
   fetchDetails: false,
   autoFocus: false,
@@ -831,8 +844,9 @@ GooglePlacesAutocomplete.defaultProps = {
   textInputHide: false,
   suppressDefaultStyles: false,
   numberOfLines: 1,
-  onSubmitEditing: () => {},
-  editable: true
+  onSubmitEditing: () => { },
+  editable: true,
+  loaderRight: false
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0


### PR DESCRIPTION
Example:
```js
<GooglePlacesAutocomplete
  (...)
  loaderRight={true} // this will render the ActivityIndicator after the text
  styles={{
    loader: {
      justifyContent: "center",
      alignContent: "center",
      height: "100%"
    },
    activityIndicator: {
      size: "large",
      color: "#ccc"
    }
  }}
/>
```