### PR TITLE
Allow custom input component

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -699,8 +699,10 @@ export default class GooglePlacesAutocomplete extends Component {
     let {
       onFocus,
       clearButtonMode,
+      InputComp
       ...userProps
     } = this.props.textInputProps;
+    const TextInputComp = !!InputComp ? InputComp : TextInput;
     return (
       <View
         style={[this.props.suppressDefaultStyles ? {} : defaultStyles.container, this.props.styles.container]}
@@ -711,7 +713,7 @@ export default class GooglePlacesAutocomplete extends Component {
             style={[this.props.suppressDefaultStyles ? {} : defaultStyles.textInputContainer, this.props.styles.textInputContainer]}
           >
             {this._renderLeftButton()}
-            <TextInput
+            <TextInputComp
               ref="textInput"
               editable={this.props.editable}
               returnKeyType={this.props.returnKeyType}

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -699,7 +699,7 @@ export default class GooglePlacesAutocomplete extends Component {
     let {
       onFocus,
       clearButtonMode,
-      InputComp
+      InputComp,
       ...userProps
     } = this.props.textInputProps;
     const TextInputComp = !!InputComp ? InputComp : TextInput;


### PR DESCRIPTION
I am using react-native-paper in my project, this allows me to pass in react-native-paper TextInput instead which accepts the default input props plus additional props. A better way me be to pass a render function, but that's a little different design.