### PR TITLE
Empty label pr

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -224,6 +224,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
   _onPress = (rowData) => {
     if (rowData.isEmptyListLabel && this.props.onEmptyListPress) {
+      this.triggerBlur(); // hide keyboard but not the results
       this.props.onEmptyListPress();
     } else if (rowData.isPredefinedPlace !== true && this.props.fetchDetails === true) {
       if (rowData.isLoading === true) {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -113,8 +113,17 @@ export default class GooglePlacesAutocomplete extends Component {
       isPredefinedPlace: true
     }));
 
-    return [...res, ...results];
-  }
+    res = [...res, ...results];
+
+    if (res.length === 0 && this.props.emptyListLabel) {
+      res.unshift({
+        description: this.props.emptyListLabel,
+        isEmptyListLabel: true,
+      });
+    }
+
+    return res;
+  };
 
   componentWillMount() {
     this._request = this.props.debounce
@@ -216,7 +225,9 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   _onPress = (rowData) => {
-    if (rowData.isPredefinedPlace !== true && this.props.fetchDetails === true) {
+    if (rowData.isEmptyListLabel && this.props.onEmptyListPress) {
+      this.props.onEmptyListPress();
+    } else if (rowData.isPredefinedPlace !== true && this.props.fetchDetails === true) {
       if (rowData.isLoading === true) {
         // already requesting
         return;
@@ -509,7 +520,7 @@ export default class GooglePlacesAutocomplete extends Component {
       });
     }
   }
-  
+
   clearText(){
     this.setState({
       text: ""
@@ -784,7 +795,9 @@ GooglePlacesAutocomplete.propTypes = {
   suppressDefaultStyles: PropTypes.bool,
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  emptyListLabel: PropTypes.string,
+  onEmptyListPress: PropTypes.func,
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -832,7 +845,9 @@ GooglePlacesAutocomplete.defaultProps = {
   suppressDefaultStyles: false,
   numberOfLines: 1,
   onSubmitEditing: () => {},
-  editable: true
+  editable: true,
+  emptyListLabel: undefined,
+  onEmptyListPress: () => {},
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -96,8 +96,6 @@ export default class GooglePlacesAutocomplete extends Component {
 
   buildRowsFromResults = (results) => {
     let res = [];
-    let { text } = this.state;
-    let { minLength } = this.props;
 
     if (results.length === 0 || this.props.predefinedPlacesAlwaysVisible === true) {
       res = [...this.props.predefinedPlaces];
@@ -115,7 +113,7 @@ export default class GooglePlacesAutocomplete extends Component {
       isPredefinedPlace: true
     }));
 
-    if (results.length === 0 && this.text.length >= minLength && this.props.emptyListLabel) {
+    if (results.length === 0 && this.state && this.state.text.length >= this.props.minLength && this.props.emptyListLabel) {
       res.unshift({
         description: this.props.emptyListLabel,
         isEmptyListLabel: true,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -96,6 +96,8 @@ export default class GooglePlacesAutocomplete extends Component {
 
   buildRowsFromResults = (results) => {
     let res = [];
+    let { text } = this.state;
+    let { minLength } = this.props;
 
     if (results.length === 0 || this.props.predefinedPlacesAlwaysVisible === true) {
       res = [...this.props.predefinedPlaces];
@@ -113,16 +115,14 @@ export default class GooglePlacesAutocomplete extends Component {
       isPredefinedPlace: true
     }));
 
-    res = [...res, ...results];
-
-    if (res.length === 0 && this.props.emptyListLabel) {
+    if (results.length === 0 && this.text.length >= minLength && this.props.emptyListLabel) {
       res.unshift({
         description: this.props.emptyListLabel,
         isEmptyListLabel: true,
       });
     }
 
-    return res;
+    return [...res, ...results];
   };
 
   componentWillMount() {


### PR DESCRIPTION
When the api returns no results we can add a label to show this to the user. If the user clicks on this label we might want to do something (show an alert with more explanations for example).

This PR adds this functionality by adding two props `emptyListLabel` and `onEmptyListPress`.