### PR TITLE
geolocation fixed for react-native 0.60

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -17,6 +17,7 @@ import {
 } from 'react-native';
 import Qs from 'qs';
 import debounce from 'lodash.debounce';
+import Geolocation from "@react-native-community/geolocation";
 
 const WINDOW = Dimensions.get('window');
 
@@ -188,7 +189,7 @@ export default class GooglePlacesAutocomplete extends Component {
       }
     }
 
-    navigator.geolocation.getCurrentPosition(
+    Geolocation.getCurrentPosition(
       (position) => {
         if (this.props.nearbyPlacesAPI === 'None') {
           let currentLocation = {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/FaridSafi/react-native-google-places-autocomplete#readme",
   "dependencies": {
+    "@react-native-community/geolocation": "^1.4.2",
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.5.10",
     "qs": "^5.2.0"


### PR DESCRIPTION
this pull request replace the deprecated navigator.geolocation by the community package @react-native-community/geolocation.