### PR TITLE
Restricting autocomplete fields to basic fields

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -18,9 +18,6 @@ import {
 import Qs from 'qs';
 import debounce from 'lodash.debounce';
 
-const BASICFIELDS =
-  'address_component,adr_address,formatted_address,geometry,icon,name,permanently_closed,photo,place_id,plus_code,type,url,utc_offset,vicinity';
-
 const WINDOW = Dimensions.get('window');
 
 const defaultStyles = {
@@ -289,7 +286,7 @@ export default class GooglePlacesAutocomplete extends Component {
         key: this.props.query.key,
         placeid: rowData.place_id,
         language: this.props.query.language,
-        fields: BASICFIELDS,
+        fields: this.props.autocompleteFields,
         ...this.props.GooglePlacesDetailsQuery,
       }));
 
@@ -788,7 +785,8 @@ GooglePlacesAutocomplete.propTypes = {
   suppressDefaultStyles: PropTypes.bool,
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  autocompleteFields: PropTypes.string.isRequired,
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -836,7 +834,8 @@ GooglePlacesAutocomplete.defaultProps = {
   suppressDefaultStyles: false,
   numberOfLines: 1,
   onSubmitEditing: () => {},
-  editable: true
+  editable: true,
+  autocompleteFields: 'geometry,type',
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -17,6 +17,9 @@ import {
 import Qs from 'qs';
 import debounce from 'lodash.debounce';
 
+const BASICFIELDS =
+  'address_component, adr_address, formatted_address, geometry, icon, name, permanently_closed, photo, place_id, plus_code, type, url, utc_offset, vicinity';
+
 const WINDOW = Dimensions.get('window');
 
 const defaultStyles = {
@@ -283,6 +286,7 @@ export default class GooglePlacesAutocomplete extends Component {
         key: this.props.query.key,
         placeid: rowData.place_id,
         language: this.props.query.language,
+        fields: BASICFIELDS,
       }));
 
       if (this.props.query.origin !== null) {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -786,7 +786,7 @@ GooglePlacesAutocomplete.propTypes = {
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
   editable: PropTypes.bool,
-  autocompleteFields: PropTypes.string.isRequired,
+  autocompleteFields: PropTypes.string,
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -18,7 +18,7 @@ import Qs from 'qs';
 import debounce from 'lodash.debounce';
 
 const BASICFIELDS =
-  'address_component, adr_address, formatted_address, geometry, icon, name, permanently_closed, photo, place_id, plus_code, type, url, utc_offset, vicinity';
+  'address_component,adr_address,formatted_address,geometry,icon,name,permanently_closed,photo,place_id,plus_code,type,url,utc_offset,vicinity';
 
 const WINDOW = Dimensions.get('window');
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const GooglePlacesInput = () => {
       minLength={2} // minimum length of text to search
       autoFocus={false}
       returnKeyType={'search'} // Can be left out for default return key https://facebook.github.io/react-native/docs/textinput.html#returnkeytype
+      autocompleteFields={'address_component,geometry,url'} // Specific fields being requested https://developers.google.com/places/web-service/details#fields
       keyboardAppearance={'light'} // Can be left out for default keyboardAppearance https://facebook.github.io/react-native/docs/textinput.html#keyboardappearance
       listViewDisplayed='auto'    // true/false/undefined
       fetchDetails={true}


### PR DESCRIPTION
KY:
Chalupa-mobile utilizes GooglePlacesAutocomplete for location autocomplete, which currently returns all fields, most of which are unused. This is unnecessary, likely increases latency, and increases cost.

Places fields are are divided into three billing categories: Basic, Contact, and Atmosphere. Basic fields are requested by Chalupa Mobile, billed at base rate, and incur no additional charges. Contact and Atmosphere fields are unused and billed at a higher rate.

Changes:
Passing basic fields through query, ensuring we only request fields in the Basic category, and avoid requesting fields in the Contact and Atmosphere categories.

Reference:
https://developers.google.com/places/web-service/details