### PR TITLE
Update GooglePlacesAutocomplete.js

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -129,7 +129,7 @@ export default class GooglePlacesAutocomplete extends Component {
     this._isMounted = true;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let listViewDisplayed = true;
 
     if (nextProps.listViewDisplayed !== 'auto') {


### PR DESCRIPTION
For this warning in new react-native versions
WARN  Warning: componentWillReceiveProps has been renamed and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.