### PR TITLE
Update GooglePlacesAutocomplete.js

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -17,6 +17,8 @@ import {
 } from 'react-native';
 import Qs from 'qs';
 import debounce from 'lodash.debounce';
+//navigator.geolocation.getCurrentPosition is supportted in RN>60 so adding the Geolocation RNCommunity
+import Geolocation from '@react-native-community/geolocation';
 
 const WINDOW = Dimensions.get('window');
 
@@ -188,7 +190,7 @@ export default class GooglePlacesAutocomplete extends Component {
       }
     }
 
-    navigator.geolocation.getCurrentPosition(
+     Geolocation.getCurrentPosition(
       (position) => {
         if (this.props.nearbyPlacesAPI === 'None') {
           let currentLocation = {


### PR DESCRIPTION
To support RN >=60 and resolve the issue "TypeError: undefined is not an object (evaluating 'navigator.geolocation.GetCurrentPosition'