### PR TITLE
Add no result component and use google id for key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ const GooglePlacesInput = () => {
       debounce={200} // debounce the requests in ms. Set to 0 to remove debounce. By default 0ms.
       renderLeftButton={()  => <Image source={require('path/custom/left-icon')} />}
       renderRightButton={() => <Text>Custom text after the input</Text>}
+      renderHeaderComponent={() => <Custom>Custom component to be rendered as the results list header</Custom>}
+      renderNoResults={() => <Custom>Custom component to be rendered when no results are found</Custom>}
     />
   );
 }


### PR DESCRIPTION
In order to give the end user a better experience, we've added this no results component in our forked version to be displayed after the request returns, but doesn't find any places.

The change to the key generation is simply to eliminate the unnecessary calculation, since Google already sends down a unique ID for each item.