### PR TITLE
Fix/location query type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -285,10 +285,7 @@ interface Query<T = AutocompleteRequestType> {
     key: string
     sessiontoken?: string
     offset?: number
-    location?: {
-        latitude: number
-        longitude: number
-    }
+    location?: string
     radius?: number
     language?: Language
     components?: string


### PR DESCRIPTION
Remove LatLng type to add string type for location. Needed for google request.