### PR TITLE
Handle invalid origin parameter for Restricted API Key

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -289,8 +289,8 @@ export default class GooglePlacesAutocomplete extends Component {
         ...this.props.GooglePlacesDetailsQuery,
       }));
 
-      if (this.props.query.origin !== null) {
-        request.setRequestHeader('Referer', this.props.query.origin)
+      if (this.props.referer !== null) {
+        request.setRequestHeader('Referer', this.props.referer)
       }
 
       request.send();
@@ -443,8 +443,8 @@ export default class GooglePlacesAutocomplete extends Component {
       }
 
       request.open('GET', url);
-      if (this.props.query.origin !== null) {
-         request.setRequestHeader('Referer', this.props.query.origin)
+      if (this.props.referer !== null) {
+         request.setRequestHeader('Referer', this.props.referer)
       }
 
       request.send();
@@ -497,8 +497,8 @@ export default class GooglePlacesAutocomplete extends Component {
         text = this.props.preProcess(text);
       }
       request.open('GET', 'https://maps.googleapis.com/maps/api/place/autocomplete/json?&input=' + encodeURIComponent(text) + '&' + Qs.stringify(this.props.query));
-      if (this.props.query.origin !== null) {
-         request.setRequestHeader('Referer', this.props.query.origin)
+      if (this.props.referer !== null) {
+         request.setRequestHeader('Referer', this.props.referer)
       }
 
       request.send();
@@ -786,7 +786,8 @@ GooglePlacesAutocomplete.propTypes = {
   suppressDefaultStyles: PropTypes.bool,
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
-  editable: PropTypes.bool
+  editable: PropTypes.bool,
+  referer: PropTypes.string
 }
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -834,7 +835,8 @@ GooglePlacesAutocomplete.defaultProps = {
   suppressDefaultStyles: false,
   numberOfLines: 1,
   onSubmitEditing: () => {},
-  editable: true
+  editable: true,
+  referer: null
 }
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0


### PR DESCRIPTION
Ref: 
* https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/140
* https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/170

I'm not sure how Google API restriction has been changed since then, but to respond to https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/489

I remove `origin` from `query` and add `referer` to `props`.

According to [the Google doc](https://developers.google.com/places/web-service/autocomplete), `origin` parameter is

> origin — The origin point from which to calculate straight-line distance to the destination (returned as distance_meters). If this value is omitted, straight-line distance will not be returned. Must be specified as latitude,longitude.

e.g. `<GooglePlacesAutocomplete referer='http://mywebsite.com' />`