### PR TITLE
Web and Expo support

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -363,6 +363,12 @@ interface GooglePlacesAutocompleteProps extends TextInputProps {
 
   renderLeftButton?: React.ComponentType<{}>;
   renderRightButton?: React.ComponentType<{}>;
+
+  // sets the request URL to something other than the google api.  Helpful if you want web support or to use your own api.
+  requestUrl?: {
+    url: string;
+    useOnPlatform: 'web' | 'all';
+  };
 }
 
 export class GooglePlacesAutocomplete extends React.Component<

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -88,8 +88,24 @@ export default class GooglePlacesAutocomplete extends Component {
       this.props.listViewDisplayed === 'auto'
         ? false
         : this.props.listViewDisplayed,
-    url: this.props.url,
+    url: this.getRequestUrl(this.props.requestUrl),
   });
+
+  getRequestUrl = (requestUrl) => {
+    if (requestUrl) {
+      if (requestUrl.useOnPlatform === 'all') {
+        return requestUrl.url;
+      }
+      if (requestUrl.useOnPlatform === 'web') {
+        return Platform.select({
+          web: requestUrl.url,
+          default: 'https://maps.googleapis.com/maps/api',
+        });
+      }
+    } else {
+      return 'https://maps.googleapis.com/maps/api';
+    }
+  };
 
   setAddressText = (address) => this.setState({ text: address });
 
@@ -316,7 +332,11 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials = true;
+      request.withCredentials =
+        this.state.url === 'https://maps.googleapis.com/maps/api'
+          ? true
+          : false; // todo we should have this be passed through the prop.
+
       request.send();
     } else if (rowData.isCurrentLocation === true) {
       // display loader
@@ -488,7 +508,11 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials = true;
+      request.withCredentials =
+        this.state.url === 'https://maps.googleapis.com/maps/api'
+          ? true
+          : false; // todo we should have this be passed through the prop.
+
       request.send();
     } else {
       this._results = [];
@@ -555,7 +579,11 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials = true;
+      request.withCredentials =
+        this.state.url === 'https://maps.googleapis.com/maps/api'
+          ? true
+          : false; // todo we should have this be passed through the prop.
+
       request.send();
     } else {
       this._results = [];
@@ -902,7 +930,10 @@ GooglePlacesAutocomplete.propTypes = {
   onSubmitEditing: PropTypes.func,
   editable: PropTypes.bool,
   referer: PropTypes.string,
-  url: PropTypes.string,
+  requestUrl: PropTypes.shape({
+    url: PropTypes.string,
+    useOnPlatform: PropTypes.oneOf(['web', 'all']),
+  }),
 };
 GooglePlacesAutocomplete.defaultProps = {
   placeholder: 'Search',
@@ -952,7 +983,6 @@ GooglePlacesAutocomplete.defaultProps = {
   onSubmitEditing: () => {},
   editable: true,
   referer: null,
-  url: 'https://maps.googleapis.com/maps/api',
 };
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -107,6 +107,9 @@ export default class GooglePlacesAutocomplete extends Component {
     }
   };
 
+  requestShouldUseWithCredentials = () =>
+    this.state.url === 'https://maps.googleapis.com/maps/api';
+
   setAddressText = (address) => this.setState({ text: address });
 
   getAddressText = () => this.state.text;
@@ -343,10 +346,7 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials =
-        this.state.url === 'https://maps.googleapis.com/maps/api'
-          ? true
-          : false; // todo we should have this be passed through the prop.
+      request.withCredentials = this.requestShouldUseWithCredentials();
 
       request.send();
     } else if (rowData.isCurrentLocation === true) {
@@ -519,10 +519,7 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials =
-        this.state.url === 'https://maps.googleapis.com/maps/api'
-          ? true
-          : false; // todo we should have this be passed through the prop.
+      request.withCredentials = this.requestShouldUseWithCredentials();
 
       request.send();
     } else {
@@ -590,10 +587,7 @@ export default class GooglePlacesAutocomplete extends Component {
         request.setRequestHeader('Referer', this.props.referer);
       }
 
-      request.withCredentials =
-        this.state.url === 'https://maps.googleapis.com/maps/api'
-          ? true
-          : false; // todo we should have this be passed through the prop.
+      request.withCredentials = this.requestShouldUseWithCredentials();
 
       request.send();
     } else {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -183,6 +183,17 @@ export default class GooglePlacesAutocomplete extends Component {
     this._requests = [];
   };
 
+  supportedPlatform(from) {
+    if (Platform.OS === 'web' && !this.props.requestUrl) {
+      console.error(
+        'This library cannot be used for the web unless you specify the requestUrl prop. See https://git.io/JflFv more for details.',
+      );
+      return false;
+    } else {
+      return true;
+    }
+  }
+
   /**
    * This method is exposed to parent components to focus on textInput manually.
    * @public
@@ -790,6 +801,7 @@ export default class GooglePlacesAutocomplete extends Component {
     const keyGenerator = () => Math.random().toString(36).substr(2, 10);
 
     if (
+      this.supportedPlatform() &&
       (this.state.text !== '' ||
         this.props.predefinedPlaces.length ||
         this.props.currentLocation === true) &&

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -952,7 +952,7 @@ GooglePlacesAutocomplete.defaultProps = {
   placeholderTextColor: '#A8A8A8',
   isRowScrollable: true,
   underlineColorAndroid: 'transparent',
-  returnKeyType: 'default',
+  returnKeyType: 'search',
   keyboardAppearance: 'default',
   onPress: () => {},
   onNotFound: () => {},

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -535,7 +535,7 @@ export default class GooglePlacesAutocomplete extends Component {
 
   _request = (text) => {
     this._abortRequests();
-    if (text.length >= this.props.minLength) {
+    if (this.supportedPlatform() && text.length >= this.props.minLength) {
       const request = new XMLHttpRequest();
       this._requests.push(request);
       request.timeout = this.props.timeout;

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Customizable Google Places autocomplete component for iOS and Android React-Native apps
 
-### Preview
+## Preview
 
 ![](https://raw.githubusercontent.com/FaridSafi/react-native-google-places-autocomplete/master/Assets/screenshot.png)
 
-### Installation
+## Installation
 
 1. `npm install react-native-google-places-autocomplete --save`
 2. Get your [Google Places API keys](https://developers.google.com/places/documentation/) and enable "Google Places API Web Service" (NOT Android or iOS) in the console.
 3. Enable "Google Maps Geocoding API" if you want to use GoogleReverseGeocoding for Current Location
 
-### Example
+## Example
 
 ```jsx
 import React from 'react';
@@ -93,7 +93,7 @@ const GooglePlacesInput = () => {
 };
 ```
 
-### Styling
+## Styling
 
 `GooglePlacesAutocomplete` can be easily customized to meet styles of your app. Pass styles props to `GooglePlacesAutocomplete` with style object for different elements (keys for style object are listed below)
 
@@ -111,7 +111,7 @@ const GooglePlacesInput = () => {
 | separator                   | object (View style)     |
 | row                         | object (View style)     |
 
-#### Example
+### Example
 
 ```jsx
 <GooglePlacesAutocomplete
@@ -141,7 +141,11 @@ const GooglePlacesInput = () => {
 />
 ```
 
-### Features
+## Web Support
+
+Web support can be enabled via the `requestUrl` prop, by passing in a URL that you can use to proxy your requests. CORS implemented by the Google Places API prevent using this library directly on the web. You can use a proxy server like [CORS Anywhere](https://github.com/Rob--W/cors-anywhere/) or roll your own. Please be mindful of this limitation when opening an issue.
+
+## Features
 
 - [x] Places autocompletion
 - [x] iOS and Android compatibility
@@ -155,7 +159,7 @@ const GooglePlacesInput = () => {
 
 ### Changelog
 
-- 1.4.2 : Added Typescript types + referer prop for restricted api key + update dependencies.
+- 1.4.2+: Please see the [releases](https://github.com/FaridSafi/react-native-google-places-autocomplete/releases) tab for the changelog information.
 - 1.3.9 : Multiple bugfixes + fixed breaking change in React Native.
 - 1.3.6 : Fixed accuracy issue.
 - 1.3.5 : Fixed bug where input was being cleared.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ const GooglePlacesInput = () => {
 
 Web support can be enabled via the `requestUrl` prop, by passing in a URL that you can use to proxy your requests. CORS implemented by the Google Places API prevent using this library directly on the web. You can use a proxy server like [CORS Anywhere](https://github.com/Rob--W/cors-anywhere/) or roll your own. Please be mindful of this limitation when opening an issue.
 
+**_Note:_** The library expects the same response that the Google Maps API would return.
+
 ## Features
 
 - [x] Places autocompletion


### PR DESCRIPTION
This is a work in-progress PR for web support, addressing 2 issues.

1) Because we are using `module.exports` this was incompatible with webpack, and by extension Expo web, CRA, Next.js etc.

2) Making a GET request on the web doesn't work because of CORS issues.  This PR adds a prop that allows you to specify the request url for web requests, to make it easier to use a proxy server.

The bulk of the work in this PR was done in #514. 

closed #389
closes #414
closes #436
closes #499
closes #525
