### PR TITLE
Fix Navigator Crash

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -123,7 +123,11 @@ export default class GooglePlacesAutocomplete extends Component {
     ) {
       res = [...this.props.predefinedPlaces];
 
-      if (this.props.currentLocation === true) {
+      if (
+        this.props.currentLocation === true &&
+        navigator &&
+        navigator.geolocation
+      ) {
         res.unshift({
           description: this.props.currentLocationLabel,
           isCurrentLocation: true,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -110,6 +110,17 @@ export default class GooglePlacesAutocomplete extends Component {
   requestShouldUseWithCredentials = () =>
     this.state.url === 'https://maps.googleapis.com/maps/api';
 
+  hasNavigator = () => {
+    if (navigator && navigator.geolocation) {
+      return true;
+    } else {
+      console.warn(
+        'If you are using React Native v0.60.0+ you must follow these instructions to enable currentLocation: https://git.io/Jf4AR',
+      );
+      return false;
+    }
+  };
+
   setAddressText = (address) => this.setState({ text: address });
 
   getAddressText = () => this.state.text;
@@ -123,11 +134,7 @@ export default class GooglePlacesAutocomplete extends Component {
     ) {
       res = [...this.props.predefinedPlaces];
 
-      if (
-        this.props.currentLocation === true &&
-        navigator &&
-        navigator.geolocation
-      ) {
+      if (this.props.currentLocation === true && this.hasNavigator()) {
         res.unshift({
           description: this.props.currentLocationLabel,
           isCurrentLocation: true,
@@ -192,8 +199,8 @@ export default class GooglePlacesAutocomplete extends Component {
 
   supportedPlatform(from) {
     if (Platform.OS === 'web' && !this.props.requestUrl) {
-      console.error(
-        'This library cannot be used for the web unless you specify the requestUrl prop. See https://git.io/JflFv more for details.',
+      console.warn(
+        'This library cannot be used for the web unless you specify the requestUrl prop. See https://git.io/JflFv for more for details.',
       );
       return false;
     } else {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,84 @@ Customizable Google Places autocomplete component for iOS and Android React-Nati
 2. Get your [Google Places API keys](https://developers.google.com/places/documentation/) and enable "Google Places API Web Service" (NOT Android or iOS) in the console.
 3. Enable "Google Maps Geocoding API" if you want to use GoogleReverseGeocoding for Current Location
 
-## Example
+## Basic Example
+
+**Basic Address Search**
+
+```jsx
+import React from 'react';
+import { Image, Text } from 'react-native';
+import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete';
+
+const GooglePlacesInput = () => {
+  return (
+    <GooglePlacesAutocomplete
+      placeholder='Search'
+      onPress={(data, details = null) => {
+        // 'details' is provided when fetchDetails = true
+        console.log(data, details);
+      }}
+      query={{
+        key: 'YOUR API KEY',
+        language: 'en',
+      }}
+    />
+  );
+};
+
+export default GooglePlacesInput;
+```
+
+You can also try the basic example in a snack [here](https://snack.expo.io/@sbell/react-native-google-places-autocomplete)
+
+## More Examples
+
+**Get Current Location**
+
+_Extra step required!_
+
+<details>
+  <summary>Click to expand!</summary>
+
+If you are targeting React Native 0.60.0+ you must install either `@react-native-community/geolocation` ([link](https://github.com/react-native-community/react-native-geolocation)) or `react-native-geolocation-service`(\[link](https://github.com/Agontuk/react-native-geolocation-service)).
+
+Please make sure you follow the installation instructions there and add `navigator.geolocation = require(GEOLOCATION_PACKAGE)` somewhere in you application before `<GooglePlacesAutocomplete />`.
+
+```jsx
+import React from 'react';
+import { Image, Text } from 'react-native';
+import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete';
+
+// navigator.geolocation = require('@react-native-community/geolocation');
+// navigator.geolocation = require('react-native-geolocation-service');
+
+const GooglePlacesInput = () => {
+  return (
+    <GooglePlacesAutocomplete
+      placeholder='Search'
+      onPress={(data, details = null) => {
+        // 'details' is provided when fetchDetails = true
+        console.log(data, details);
+      }}
+      query={{
+        key: 'YOUR API KEY',
+        language: 'en',
+      }}
+      currentLocation={true}
+      currentLocationLabel='Current location'
+    />
+  );
+};
+
+export default GooglePlacesInput;
+```
+
+</details>
+
+**Search with predefined option**
+
+<details>
+  <summary>Click to expand!</summary>
 
 ```jsx
 import React from 'react';
@@ -32,68 +109,55 @@ const GooglePlacesInput = () => {
   return (
     <GooglePlacesAutocomplete
       placeholder='Search'
-      minLength={2} // minimum length of text to search
-      autoFocus={false}
-      returnKeyType={'search'} // Can be left out for default return key https://facebook.github.io/react-native/docs/textinput.html#returnkeytype
-      keyboardAppearance={'light'} // Can be left out for default keyboardAppearance https://facebook.github.io/react-native/docs/textinput.html#keyboardappearance
-      listViewDisplayed='auto' // true/false/undefined
-      fetchDetails={true}
-      renderDescription={(row) => row.description} // custom description render
       onPress={(data, details = null) => {
         // 'details' is provided when fetchDetails = true
         console.log(data, details);
       }}
-      getDefaultValue={() => ''}
       query={{
-        // available options: https://developers.google.com/places/web-service/autocomplete
         key: 'YOUR API KEY',
-        language: 'en', // language of the results
-        types: '(cities)', // default: 'geocode'
+        language: 'en',
       }}
-      styles={{
-        textInputContainer: {
-          width: '100%',
-        },
-        description: {
-          fontWeight: 'bold',
-        },
-        predefinedPlacesDescription: {
-          color: '#1faadb',
-        },
-      }}
-      currentLocation={true} // Will add a 'Current location' button at the top of the predefined places list
-      currentLocationLabel='Current location'
-      nearbyPlacesAPI='GooglePlacesSearch' // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
-      GoogleReverseGeocodingQuery={
-        {
-          // available options for GoogleReverseGeocoding API : https://developers.google.com/maps/documentation/geocoding/intro
-        }
-      }
-      GooglePlacesSearchQuery={{
-        // available options for GooglePlacesSearch API : https://developers.google.com/places/web-service/search
-        rankby: 'distance',
-        type: 'cafe',
-      }}
-      GooglePlacesDetailsQuery={{
-        // available options for GooglePlacesDetails API : https://developers.google.com/places/web-service/details
-        fields: 'formatted_address',
-      }}
-      filterReverseGeocodingByTypes={[
-        // filter the reverse geocoding results by types - ['locality', 'administrative_area_level_3'] if you want to display only cities
-        // available options : https://developers.google.com/maps/documentation/geocoding/intro#Types
-        'locality',
-        'administrative_area_level_3',
-      ]}
       predefinedPlaces={[homePlace, workPlace]}
-      debounce={200} // debounce the requests in ms. Set to 0 to remove debounce. By default 0ms.
-      renderLeftButton={() => (
-        <Image source={require('path/custom/left-icon')} />
-      )}
-      renderRightButton={() => <Text>Custom text after the input</Text>}
     />
   );
 };
+
+export default GooglePlacesInput;
 ```
+
+</details>
+
+**Limit results to one country**
+
+<details>
+  <summary>Click to expand!</summary>
+
+```jsx
+import React from 'react';
+import { Image, Text } from 'react-native';
+import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete';
+
+const GooglePlacesInput = () => {
+  return (
+    <GooglePlacesAutocomplete
+      placeholder='Search'
+      onPress={(data, details = null) => {
+        // 'details' is provided when fetchDetails = true
+        console.log(data, details);
+      }}
+      query={{
+        key: 'YOUR API KEY',
+        language: 'en',
+        components: 'country:us',
+      }}
+    />
+  );
+};
+
+export default GooglePlacesInput;
+```
+
+</details>
 
 ## Styling
 
@@ -139,7 +203,6 @@ const GooglePlacesInput = () => {
       color: '#1faadb',
     },
   }}
-  currentLocation={false}
 />
 ```
 
@@ -159,7 +222,7 @@ Web support can be enabled via the `requestUrl` prop, by passing in a URL that y
 - [x] Google Places terms compliant
 - [x] Predefined places
 - [x] typescript types
-- [ ] Current location
+- [x] Current location
 
 ### Changelog
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ You can also try the basic example in a snack [here](https://snack.expo.io/@sbel
 
 **Get Current Location**
 
+<details>
+  <summary>Click to expand</summary>
+
 _Extra step required!_
 
-<details>
-  <summary>Click to expand!</summary>
-
-If you are targeting React Native 0.60.0+ you must install either `@react-native-community/geolocation` ([link](https://github.com/react-native-community/react-native-geolocation)) or `react-native-geolocation-service`(\[link](https://github.com/Agontuk/react-native-geolocation-service)).
+If you are targeting React Native 0.60.0+ you must install either `@react-native-community/geolocation` ([link](https://github.com/react-native-community/react-native-geolocation)) or `react-native-geolocation-service`([link](https://github.com/Agontuk/react-native-geolocation-service)).
 
 Please make sure you follow the installation instructions there and add `navigator.geolocation = require(GEOLOCATION_PACKAGE)` somewhere in you application before `<GooglePlacesAutocomplete />`.
 
@@ -89,7 +89,7 @@ export default GooglePlacesInput;
 **Search with predefined option**
 
 <details>
-  <summary>Click to expand!</summary>
+  <summary>Click to expand</summary>
 
 ```jsx
 import React from 'react';
@@ -130,7 +130,7 @@ export default GooglePlacesInput;
 **Limit results to one country**
 
 <details>
-  <summary>Click to expand!</summary>
+  <summary>Click to expand</summary>
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
This PR fixes a crash when selecting `currentLocation` in React Native v0.60.0+, since `navigator.geolocation` was [deprecated in React Native v0.60.0](https://reactnative.dev/docs/geolocation.html).

Instead of including a geolocation library as a dependency, this requires that you define `navigator.geolocation = require('SOME_GEOLOCATION_LIBRARY')` somewhere in your app.
This also means we get compatibility for the web out of the box and the library remains backwards compatible. 

I also cleanup some of the examples in the Readme, but there is still a lot of work to do there.

closes #541 
closes #447 
closes #473
closes #493