### PR TITLE
fix(referrer prop) restrict referrer prop to web only

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -353,7 +353,7 @@ export default class GooglePlacesAutocomplete extends Component {
           }),
       );
 
-      if (this.props.referer !== null) {
+      if (this.props.referer !== null && Platform.OS === 'web') {
         request.setRequestHeader('Referer', this.props.referer);
       }
 


### PR DESCRIPTION
### Fix

This small fix ensures that the `referrer` prop will only work when used in web apps and will be ignored in native apps (iOS/Android).

Signed-off-by: Sam Apter <sam.apter@brandingbrand.com>