### PR TITLE
remove referer prop

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -353,10 +353,6 @@ export default class GooglePlacesAutocomplete extends Component {
           }),
       );
 
-      if (this.props.referer !== null) {
-        request.setRequestHeader('Referer', this.props.referer);
-      }
-
       request.withCredentials = this.requestShouldUseWithCredentials();
 
       request.send();
@@ -526,9 +522,6 @@ export default class GooglePlacesAutocomplete extends Component {
       }
 
       request.open('GET', url);
-      if (this.props.referer !== null) {
-        request.setRequestHeader('Referer', this.props.referer);
-      }
 
       request.withCredentials = this.requestShouldUseWithCredentials();
 
@@ -598,9 +591,6 @@ export default class GooglePlacesAutocomplete extends Component {
           '&' +
           Qs.stringify(this.props.query),
       );
-      if (this.props.referer !== null) {
-        request.setRequestHeader('Referer', this.props.referer);
-      }
 
       request.withCredentials = this.requestShouldUseWithCredentials();
 
@@ -950,7 +940,6 @@ GooglePlacesAutocomplete.propTypes = {
   numberOfLines: PropTypes.number,
   onSubmitEditing: PropTypes.func,
   editable: PropTypes.bool,
-  referer: PropTypes.string,
   requestUrl: PropTypes.shape({
     url: PropTypes.string,
     useOnPlatform: PropTypes.oneOf(['web', 'all']),
@@ -1003,7 +992,6 @@ GooglePlacesAutocomplete.defaultProps = {
   numberOfLines: 1,
   onSubmitEditing: () => {},
   editable: true,
-  referer: null,
 };
 
 // this function is still present in the library to be retrocompatible with version < 1.1.0

--- a/README.md
+++ b/README.md
@@ -224,25 +224,27 @@ Web support can be enabled via the `requestUrl` prop, by passing in a URL that y
 - [x] typescript types
 - [x] Current location
 
-### Changelog
+## Compatibility
 
-- 1.4.2+: Please see the [releases](https://github.com/FaridSafi/react-native-google-places-autocomplete/releases) tab for the changelog information.
-- 1.3.9 : Multiple bugfixes + fixed breaking change in React Native.
-- 1.3.6 : Fixed accuracy issue.
-- 1.3.5 : Fixed bug where input was being cleared.
-- 1.3.4 : Fixed bug where loading was breaking the component.
-- 1.3.3 : Fixed `key prop` warning and added loading indicator.
-- 1.3.2 : Added small feature which makes the request on `componentDidMount()` when you
-  already have the default value set.
-- 1.3.1 : Update `react-native` peerDependecy. (> 0.46)
-- 1.3.0 : Added support for React 16 (isMounted() and propTypes bugfix), support for restricted API key and moving from `ListView` to `Flatlist`.
-- 1.2.12 : Fixed render description + docs.
-- 1.2.11 : Fixed current location result `onPress` event.
-- 1.2.10 : Set default `debounce` to `0`. Fixed debounce typing lag.
-- 1.2.9 : Added `isRowScrollable` prop.
-- 1.2.8 : Added `underlineColorAndroid`, `listUnderlayColor`, `renderLeftButton`, `renderRightButton` props. Added `nearbyPlacesAPI` option `None`.
+This library does not use the iOS, Android or JS SDKs from Google. This comes with some Pros and Cons.
 
-### License
+**Pros:**
+
+- smaller app size
+- better privacy for your users (although Google still tracks server calls)
+- no need to keep up with sdk updates
+
+**Cons:**
+
+- the library is not compatible with a Application key restrictions
+- doesn't work directly on the web without a proxy server
+- any Google API change can be a breaking change for the library.
+
+## Changelog
+
+Please see the [releases](https://github.com/FaridSafi/react-native-google-places-autocomplete/releases) tab for the changelog information.
+
+## License
 
 [MIT](LICENSE)
 


### PR DESCRIPTION
This PR reverts #526 and entirely remove support for passing a referer header. 
This library is not compatible with restricted API keys, as we don't use the native or JS sdks. 

Still in progress:  Adding back the `origin` prop, ~either in this PR or a follow up~.
Edit: It looks like you can add `origin` directly to `query`, `GoogleReverseGeocodingQuery`, `GooglePlacesSearchQuery`,  or `GooglePlacesDetailsQuery`, depending on which API you use.

This closes #561.