### PR TITLE
fix list hiding when selecting current location

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -368,7 +368,6 @@ export default class GooglePlacesAutocomplete extends Component {
         text: this._renderDescription(rowData),
       });
 
-      this.triggerBlur(); // hide keyboard but not the results
       delete rowData.isLoading;
       this.getCurrentLocation();
     } else {


### PR DESCRIPTION
When you would select Current Location, the list would hide and you would have to click the search box again in order to see the results. 

Closes #496.