### PR TITLE
Added typescript definition for enablePoweredByContainer

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -378,6 +378,8 @@ interface GooglePlacesAutocompleteProps extends TextInputProps {
   textInputProps: TextInputProps & {
     ref?: React.MutableRefObject<TextInput | null> | undefined;
   };
+  
+  enablePoweredByContainer?: boolean;
 }
 
 export class GooglePlacesAutocomplete extends React.Component<


### PR DESCRIPTION
`enablePoweredByContainer` is [defined as a PropType](https://github.com/FaridSafi/react-native-google-places-autocomplete/blob/master/GooglePlacesAutocomplete.js#L920) but not in the typescript definitions.