### PR TITLE
Call onNotFound function if there are no results.

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -551,6 +551,10 @@ export default class GooglePlacesAutocomplete extends Component {
 
         if (request.status === 200) {
           const responseJSON = JSON.parse(request.responseText);
+          if(responseJSON.status === 'ZERO_RESULTS'){
+              this.props.onNotFound && this.props.onNotFound(responseJSON);
+              return;
+          }
           if (typeof responseJSON.predictions !== 'undefined') {
             if (this._isMounted === true) {
               const results =

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -551,10 +551,6 @@ export default class GooglePlacesAutocomplete extends Component {
 
         if (request.status === 200) {
           const responseJSON = JSON.parse(request.responseText);
-          if(responseJSON.status === 'ZERO_RESULTS'){
-              this.props.onNotFound && this.props.onNotFound(responseJSON);
-              return;
-          }
           if (typeof responseJSON.predictions !== 'undefined') {
             if (this._isMounted === true) {
               const results =

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -569,6 +569,9 @@ export default class GooglePlacesAutocomplete extends Component {
               this.setState({
                 dataSource: this.buildRowsFromResults(results),
               });
+              if(responseJSON.status === 'ZERO_RESULTS'){
+                this.props.onNotFound && this.props.onNotFound(responseJSON);
+              }
             }
           }
           if (typeof responseJSON.error_message !== 'undefined') {


### PR DESCRIPTION
When Google places autocomplete API returns with no results 
We can take advantage of an existing API and call `onNotFound`
This is an alternative for this [PR](https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/425) 

I believe this is a cleaner way to report to the callee and the callee can decide more freely which UI he wants to render