### PR TITLE
fix autocomplete query with location

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -583,6 +583,9 @@ export default class GooglePlacesAutocomplete extends Component {
       if (this.props.preProcess) {
         text = this.props.preProcess(text);
       }
+      if (this.props.query.location && this.props.query.location.latitude && this.props.query.location.longitude) {
+        this.props.query.location = `${this.props.query.location.latitude},${this.props.query.location.longitude}`;
+      }
       request.open(
         'GET',
         `${this.state.url}/place/autocomplete/json?&input=` +


### PR DESCRIPTION
It fixes the search autocomplete query mount.
Accordingly with Google Docs ([here](https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests)) it should be mounted as `location=lat,lng`, and was being wrongly mounted because of its object type.
![image](https://user-images.githubusercontent.com/4589857/85183098-f974b000-b260-11ea-840b-17ebe1c9e032.png)

![image](https://user-images.githubusercontent.com/4589857/85183088-ea8dfd80-b260-11ea-820d-2e3410d2c99b.png)
