### PR TITLE
Fix usage with react-native-service-location

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -247,8 +247,8 @@ export default class GooglePlacesAutocomplete extends Component {
         timeout: 20000,
       };
     }
-
-    navigator.geolocation.getCurrentPosition(
+    const getCurrentPosition = navigator.geolocation.getCurrentPosition || navigator.geolocation.default.getCurrentPosition;
+    getCurrentPosition(
       (position) => {
         if (this.props.nearbyPlacesAPI === 'None') {
           let currentLocation = {


### PR DESCRIPTION
Fix usage of navigator.geolocation.getCurrentPosition is null

When use react-native-service-location like
```js
navigator.geolocation = require('react-native-geolocation-service');
```

When use this library it comes in `default` property. 
`navigator.geolocation.getCurrentLocation` is undefined but `navigator.geolocation.default.getCurrentLocation` is currently defined.