### PR TITLE
Add missing type definitions

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -336,6 +336,13 @@ interface GooglePlacesAutocompleteProps extends TextInputProps {
   getDefaultValue?: () => string;
   styles?: Partial<Styles>;
   suppressDefaultStyles?: boolean;
+  autoFillOnNotFound?: boolean;
+  enableHighAccuracyLocation?: boolean;
+  isRowScrollable?: boolean;
+  onNotFound?: () => void;
+  onTimeout?: () => void;
+  textInputHide?: boolean;
+  timeout?: number;
 
   // Will add a 'Current location' button at the top of the predefined places list
   currentLocation?: boolean;


### PR DESCRIPTION
@FaridSafi just noticed that some props weren't on types definition file, so I double checked every prop available on `GooglePlacesAutocomplete.propTypes` and added missing ones.

Hope to see this merged soon.
Let me know if you need any changes.

Also thanks for the amazing work here.