### PR TITLE
fixed debounceData function creation

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Qs from 'qs';
 import React, {
   forwardRef,
-  useCallback,
+  useMemo,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -520,7 +520,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const debounceData = useCallback(
+  const debounceData = useMemo(
     () => debounce(_request, props.debounce),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],


### PR DESCRIPTION
_onChangeText is calling debounceData to initiate search, with debounceData defined as useCallback it's never going to execute debounced _request method and that's why we won't get any search results.