### PR TITLE
fixed debounceData function definition

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Qs from 'qs';
 import React, {
   forwardRef,
-  useCallback,
+  useMemo,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -522,7 +522,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debounceData = useCallback(debounce(_request, props.debounce), []);
+  const debounceData = useMemo(() => debounce(_request, props.debounce), []);
 
   const _onChangeText = (text) => {
     setStateText(text);


### PR DESCRIPTION
Second try...
Prevented call to `debounce` function on every state change.

Explanation...

Current implementation:
`const debounceData = useCallback(debounce(_request, props.debounce), []);`

This will call `debounce(_request, props.debounce)` on every state change (while you are typing).
It won't change the value of `const debounceData` because `useCallback` will execute only once, but `debounce` is executed every time. Correct implementation would be with `useMemo` that will also execute only once and as a result return debounced `_request` function.