### PR TITLE
fix(ts-error): add JSX.Element type option in addition to dep React.C…

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -401,7 +401,7 @@ interface GooglePlacesAutocompleteProps {
   predefinedPlaces?: Place[];
   predefinedPlacesAlwaysVisible?: boolean;
   preProcess?: (text: string) => string;
-  query: Query;
+  query: Query | Object;
   renderDescription?: (description: DescriptionRow) => string;
   renderHeaderComponent?: () => JSX.Element | React.ComponentType<{}>;
   renderLeftButton?: () => JSX.Element | React.ComponentType<{}>;
@@ -410,11 +410,11 @@ interface GooglePlacesAutocompleteProps {
   
   // sets the request URL to something other than the google api.  Helpful if you want web support or to use your own api.
   requestUrl?: RequestUrl;
-  styles?: Partial<Styles>;
+  styles?: Partial<Styles> | Object;
   suppressDefaultStyles?: boolean;
   textInputHide?: boolean;
   // text input props
-  textInputProps?: TextInputProps;
+  textInputProps?: TextInputProps | Object;
   timeout?: number;
 }
 

--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -386,7 +386,7 @@ interface GooglePlacesAutocompleteProps {
   isRowScrollable?: boolean;
   keyboardShouldPersistTaps?: 'never' | 'always' | 'handled';
   // use the ListEmptyComponent prop when no autocomplete results are found.
-  listEmptyComponent?: React.ComponentType<{}>;
+  listEmptyComponent?: JSX.Element | React.ComponentType<{}>;
   listUnderlayColor?: string;
   listViewDisplayed?: 'auto' | boolean;
   minLength?: number; // minimum length of text to search
@@ -403,10 +403,11 @@ interface GooglePlacesAutocompleteProps {
   preProcess?: (text: string) => string;
   query: Query;
   renderDescription?: (description: DescriptionRow) => string;
-  renderHeaderComponent?: () => React.ComponentType<{}>;
-  renderLeftButton?: () => React.ComponentType<{}>;
-  renderRightButton?: () => React.ComponentType<{}>;
-  renderRow?: (data: GooglePlaceData) => React.ComponentType<{}>;
+  renderHeaderComponent?: () => JSX.Element | React.ComponentType<{}>;
+  renderLeftButton?: () => JSX.Element | React.ComponentType<{}>;
+  renderRightButton?: () => JSX.Element | React.ComponentType<{}>;
+  renderRow?: (data: GooglePlaceData) => JSX.Element | React.ComponentType<{}>;
+  
   // sets the request URL to something other than the google api.  Helpful if you want web support or to use your own api.
   requestUrl?: RequestUrl;
   styles?: Partial<Styles>;


### PR DESCRIPTION
fix componentType by adding option for JSX.Element on renderRow/LeftButton/Header etc.

should replace ComponentType with ElementType in future but did not fix for me

should fix #642 