### PR TITLE
add workaround for RNW onBlur firing too early

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -640,6 +640,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const _onBlur = () => {
+    props.textInputProps.onBlur;
     setListViewDisplayed(false);
     inputRef?.current?.blur();
   };
@@ -742,7 +743,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   let {
     onFocus,
-    onBlur,
     clearButtonMode,
     InputComp,
     ...userProps
@@ -780,14 +780,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
                   }
                 : _onFocus
             }
-            onBlur={
-              onBlur
-                ? () => {
-                    _onBlur();
-                    onBlur();
-                  }
-                : _onBlur
-            }
+            onBlur={_onBlur}
             clearButtonMode={clearButtonMode || 'while-editing'}
             onChangeText={_handleChangeText}
             {...userProps}
@@ -885,7 +878,9 @@ GooglePlacesAutocomplete.defaultProps = {
   styles: {},
   suppressDefaultStyles: false,
   textInputHide: false,
-  textInputProps: {},
+  textInputProps: {
+    onBlur: () => '',
+  },
   timeout: 20000,
 };
 


### PR DESCRIPTION
Fix for #638.

For more of background on this, see these issues - https://github.com/necolas/react-native-web/issues/1773, https://github.com/facebook/react/issues/4210.

As a workaround (read - hack),  I added an empty default blur function.

Waiting for some indication from the community that this fix is effective.