### PR TITLE
add textInput refs directly on useImperativeHandle

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -147,7 +147,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       setStateText(address);
     },
     getAddressText: () => stateText,
-    ...inputRef.current,
+    blur: () => inputRef.current.blur(),
+    focus: () => inputRef.current.focus(),
+    isFocused: () => inputRef.current.isFocused(),
+    clear: () => inputRef.current.clear(),
   }));
 
   const requestShouldUseWithCredentials = () =>


### PR DESCRIPTION
Should close #641.   

Some of the <TextInput /> refs were not always available. This PR should fix that. 