### PR TITLE
Fix onPress issue caused by blur event

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -642,8 +642,24 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     );
   };
 
-  const _onBlur = () => {
+  const isNewFocusInAutocompleteResultList = ({ relatedTarget, currentTarget }) => {
+    if (!relatedTarget) return false;
+
+    var node = relatedTarget.parentNode;
+
+    while (node) {
+      if (node.id === 'result-list-id') return true;
+      node = node.parentNode;
+    }
+
+    return false;
+  }
+
+  const _onBlur = (e) => {
+    if (e && isNewFocusInAutocompleteResultList(e)) return;
+
     setListViewDisplayed(false);
+
     inputRef?.current?.blur();
   };
 
@@ -717,6 +733,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     ) {
       return (
         <FlatList
+          nativeID="result-list-id"
           scrollEnabled={!props.disableScroll}
           style={[
             props.suppressDefaultStyles ? {} : defaultStyles.listView,
@@ -786,8 +803,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             }
             onBlur={
               onBlur
-                ? () => {
-                    _onBlur();
+                ? (e) => {
+                    _onBlur(e);
                     onBlur();
                   }
                 : _onBlur


### PR DESCRIPTION
Since pressing the the list items are calling _onBlur in the _onPress function then we could trigger a blur only if the related target does not belong to the list with address items.

So a clean candidate solution could be:

1) Attach an ID to the FlatList containing the results with clickable items

2) Call the onBlur only if the tap or click is not inside the list with results