### PR TITLE
Fix broken typechecking

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -401,7 +401,7 @@ interface GooglePlacesAutocompleteProps {
   predefinedPlaces?: Place[];
   predefinedPlacesAlwaysVisible?: boolean;
   preProcess?: (text: string) => string;
-  query: Query | Object;
+  query: Query;
   renderDescription?: (description: DescriptionRow) => string;
   renderHeaderComponent?: () => JSX.Element | React.ComponentType<{}>;
   renderLeftButton?: () => JSX.Element | React.ComponentType<{}>;
@@ -410,11 +410,11 @@ interface GooglePlacesAutocompleteProps {
   
   // sets the request URL to something other than the google api.  Helpful if you want web support or to use your own api.
   requestUrl?: RequestUrl;
-  styles?: Partial<Styles> | Object;
+  styles?: Partial<Styles>;
   suppressDefaultStyles?: boolean;
   textInputHide?: boolean;
   // text input props
-  textInputProps?: TextInputProps | Object;
+  textInputProps?: TextInputProps;
   timeout?: number;
 }
 


### PR DESCRIPTION
[This commit](https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/643/commits/1e62abd49ceaa476ee291ef53eacf71338c603ee) makes it so that the query, styles, and textInputProps are no longer type checked.  Having a union type with Object allows any object to be passed to the prop regardless of its shape.