### PR TITLE
Fix updating props.predefinedPlaces

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -141,6 +141,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  useEffect(() => {
+    // Update dataSource if props.predefinedPlaces changed
+    setDataSource(buildRowsFromResults([])) 
+  }, [props.predefinedPlaces])
 
   useImperativeHandle(ref, () => ({
     setAddressText: (address) => {


### PR DESCRIPTION
Since `const [dataSource, setDataSource] = useState(buildRowsFromResults([]));` only init once, so the later update on the `props.predefinedPlaces` will not make it rerender.