### PR TITLE
fix autocomplete url params

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -509,7 +509,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
       request.open(
         'GET',
-        `${url}/place/autocomplete/json?&input=` +
+        `${url}/place/autocomplete/json?input=` +
           encodeURIComponent(text) +
           '&' +
           Qs.stringify(props.query),


### PR DESCRIPTION
Replaced `?&input` with `?input` in autocomplete request url, this should fix filtering by type #686.

P.S. This is my first contribution to open source, please let me know if I did something wrong.