### PR TITLE
Add props.query to useMemo dependency array

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -525,7 +525,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debounceData = useMemo(() => debounce(_request, props.debounce), []);
+  const debounceData = useMemo(() => debounce(_request, props.debounce), [props.query]);
 
   const _onChangeText = (text) => {
     setStateText(text);


### PR DESCRIPTION
This will allow the `_request` function to be ran when a new `props.query` is passed in. Currently while implementing session tokens, I am running into an issue https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/702 where the `props.query.sessiontoken` is being memoized. This is causing the incorrect sessiontoken to get attached to the `places/autocomplete` call. This will also fix https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/675.