### PR TITLE
Allow Persistent Results

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -395,6 +395,7 @@ interface GooglePlacesAutocompleteProps {
   listEmptyComponent?: JSX.Element | React.ComponentType<{}>;
   listUnderlayColor?: string;
   listViewDisplayed?: 'auto' | boolean;
+  keepResultsAfterBlur?: boolean;
   minLength?: number; // minimum length of text to search
   // Which API to use: GoogleReverseGeocoding or GooglePlacesSearch
   nearbyPlacesAPI?: 'GoogleReverseGeocoding' | 'GooglePlacesSearch';

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -897,6 +897,7 @@ GooglePlacesAutocomplete.defaultProps = {
   keyboardShouldPersistTaps: 'always',
   listUnderlayColor: '#c8c7cc',
   listViewDisplayed: 'auto',
+  keepResultsAfterBlur: false,
   minLength: 0,
   nearbyPlacesAPI: 'GooglePlacesSearch',
   numberOfLines: 1,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -665,7 +665,9 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   const _onBlur = (e) => {
     if (e && isNewFocusInAutocompleteResultList(e)) return;
 
-    setListViewDisplayed(false);
+    if (!props.keepResultsAfterBlur) {
+      setListViewDisplayed(false);
+    }
     inputRef?.current?.blur();
   };
 
@@ -846,6 +848,7 @@ GooglePlacesAutocomplete.propTypes = {
   listEmptyComponent: PropTypes.func,
   listUnderlayColor: PropTypes.string,
   listViewDisplayed: PropTypes.oneOf(['auto', PropTypes.bool]),
+  keepResultsAfterBlur: PropTypes.bool,
   minLength: PropTypes.number,
   nearbyPlacesAPI: PropTypes.string,
   numberOfLines: PropTypes.number,


### PR DESCRIPTION
Results from the search can be made to persist after the blur event has been fired and focus from the input is lost.
This is helpful in a variety of situations where the on screen keyboard needs to be hidden or focus pulled elsewhere with the results from the search still visible.