### PR TITLE
Feature/ Add channel property and use it for autocomplete and details

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -426,6 +426,7 @@ interface GooglePlacesAutocompleteProps {
   /** text input props */
   textInputProps?: TextInputProps | Object;
   timeout?: number;
+  channel?: number;
 }
 
 export type GooglePlacesAutocompleteRef = {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -143,7 +143,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   }, []);
   useEffect(() => {
     // Update dataSource if props.predefinedPlaces changed
-    setDataSource(buildRowsFromResults([])) 
+    setDataSource(buildRowsFromResults([]))
   }, [props.predefinedPlaces])
 
   useImperativeHandle(ref, () => ({
@@ -294,6 +294,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             key: props.query.key,
             placeid: rowData.place_id,
             language: props.query.language,
+            channel: props.channel,
             ...props.GooglePlacesDetailsQuery,
           }),
       );
@@ -517,7 +518,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         `${url}/place/autocomplete/json?input=` +
           encodeURIComponent(text) +
           '&' +
-          Qs.stringify(props.query),
+          Qs.stringify({...props.query, channel: props.channel}),
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
@@ -877,6 +878,7 @@ GooglePlacesAutocomplete.propTypes = {
   textInputHide: PropTypes.bool,
   textInputProps: PropTypes.object,
   timeout: PropTypes.number,
+  channel: PropTypes.number,
 };
 
 GooglePlacesAutocomplete.defaultProps = {

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ _This list is a work in progress. PRs welcome!_
 | textInputHide                 | boolean  | Hide the Search input                                                                                                                                                                                                                       | false                                                             | true \| false                                              |
 | textInputProps                | object   | define props for the [textInput](https://reactnative.dev/docs/textinput), or provide a custom input component                                                                                                                               |                                                                   |                                                            |
 | timeout                       | number   | how many ms until the request will timeout                                                                                                                                                                                                  | 20000                                                             |                                                            |
-
+| channel                       | number   | used to track usage through billing reports                                                                                                                                                                                                   | | 0 - 999
 ## Methods
 
 | method name      | type                      | description                                                             |
@@ -504,9 +504,9 @@ Because the query parameters are different for each API, there are 4 different "
 3. Nearby Search -> `GooglePlacesSearchQuery` ([options](https://developers.google.com/places/web-service/search#PlaceSearchRequests))
 4. Geocode -> `GoogleReverseGeocodingQuery` ([options](https://developers.google.com/maps/documentation/geocoding/intro#GeocodingRequests))
 
-Number 1 is used while getting autocomplete results.  
-Number 2 is used when you click on a result.  
-Number 3 is used when you select 'Current Location' to load nearby results.  
+Number 1 is used while getting autocomplete results.
+Number 2 is used when you click on a result.
+Number 3 is used when you select 'Current Location' to load nearby results.
 Number 4 is used when `nearbyPlacesAPI='GoogleReverseGeocoding'` is set and you select 'Current Location' to load nearby results.
 
 ## Changelog


### PR DESCRIPTION
We added multiple spots where we were using autocomplete/details and wanted to get an idea what the breakdown was for each implementation which is what `channels` is used for https://developers.google.com/maps/reporting/gmp-reporting#usage-tracking-per-channel. 