### PR TITLE
Fix debouncing when using a controlled input component

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -466,7 +466,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text) => {
+  const _request = (text, url, headers) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -530,11 +530,11 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debounceData = useMemo(() => debounce(_request, props.debounce), [props.query]);
+  const debounceData = useMemo(() => debounce(_request, props.debounce), [props.debounce]);
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text);
+    debounceData(text, url, headers);
   };
 
   const _handleChangeText = (text) => {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -466,7 +466,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text, url, headers) => {
+  const _request = (text) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -534,7 +534,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text, url, headers);
+    debounceData(text);
   };
 
   const _handleChangeText = (text) => {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -466,7 +466,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
-  const _request = (text) => {
+  const _request = (text, requestUrl, query) => {
     _abortRequests();
     if (supportedPlatform() && text && text.length >= props.minLength) {
       const request = new XMLHttpRequest();
@@ -512,12 +512,13 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         setStateText(props.preProcess(text));
       }
 
+      const url = getRequestUrl(requestUrl);
       request.open(
         'GET',
         `${url}/place/autocomplete/json?input=` +
           encodeURIComponent(text) +
           '&' +
-          Qs.stringify(props.query),
+          Qs.stringify(query),
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
@@ -534,7 +535,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   const _onChangeText = (text) => {
     setStateText(text);
-    debounceData(text);
+    debounceData(text, props.requestUrl, props.query);
   };
 
   const _handleChangeText = (text) => {


### PR DESCRIPTION
Changes the `useMemo` dependency for `debounceData`  to correct an issue that can occur if the parent component re-renders often -  this happens if you are using a custom input control that is a controlled component. In this case, the `debounceData` function is constantly re-created due to `props.query` being a new object (even if none of its props have changed). As a result, debouncing does not function correctly and you will get a server request for every character press.

The memoized request function now takes the requestUrl and query params as arguments so that up to date values are always used.