### PR TITLE
Add header support when using custom request url

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -363,6 +363,7 @@ interface Place {
 interface RequestUrl {
   url: string;
   useOnPlatform: 'web' | 'all';
+  headers?: Record<string, string>;
 }
 
 interface GooglePlacesAutocompleteProps {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -107,6 +107,14 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     return [...res, ...results];
   };
 
+  const getRequestHeaders = (requestUrl) => {
+    if (requestUrl && requestUrl.headers) {
+      return requestUrl.headers;
+    } else {
+      return {};
+    }
+  };
+
   const getRequestUrl = (requestUrl) => {
     if (requestUrl) {
       if (requestUrl.useOnPlatform === 'all') {
@@ -123,12 +131,19 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     }
   };
 
+  const setRequestHeaders = (request, headers) => {
+    Object.keys(headers).map((headerKey) =>
+      request.setRequestHeader(headerKey, headers[headerKey]),
+    );
+  };
+
   const [stateText, setStateText] = useState('');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
   const [listViewDisplayed, setListViewDisplayed] = useState(
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
+  const [headers] = useState(getRequestHeaders(props.requestUrl));
 
   const inputRef = useRef();
 
@@ -299,6 +314,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
+      setRequestHeaders(request, headers);
 
       request.send();
     } else if (rowData.isCurrentLocation === true) {
@@ -458,6 +474,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
+      setRequestHeaders(request, headers);
 
       request.send();
     } else {
@@ -521,6 +538,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
+      setRequestHeaders(request, headers);
 
       request.send();
     } else {
@@ -871,6 +889,7 @@ GooglePlacesAutocomplete.propTypes = {
   requestUrl: PropTypes.shape({
     url: PropTypes.string,
     useOnPlatform: PropTypes.oneOf(['web', 'all']),
+    headers: PropTypes.objectOf(PropTypes.string),
   }),
   styles: PropTypes.object,
   suppressDefaultStyles: PropTypes.bool,

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -143,7 +143,13 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
-  const [headers] = useState(getRequestHeaders(props.requestUrl));
+  const [headers, setHeaders] = useState({});
+
+  useEffect(() => {
+    if (props.requestUrl) {
+      setHeaders(props.requestUrl.headers);
+    }
+  }, [props.requestUrl]);
 
   const inputRef = useRef();
 

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -143,13 +143,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
   );
   const [url] = useState(getRequestUrl(props.requestUrl));
-  const [headers, setHeaders] = useState({});
-
-  useEffect(() => {
-    if (props.requestUrl) {
-      setHeaders(props.requestUrl.headers);
-    }
-  }, [props.requestUrl]);
 
   const inputRef = useRef();
 
@@ -544,7 +537,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, getRequestHeaders(requestUrl));
+      setRequestHeaders(request, getRequestHeaders(props.requestUrl));
 
       request.send();
     } else {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -107,14 +107,6 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     return [...res, ...results];
   };
 
-  const getRequestHeaders = (requestUrl) => {
-    if (requestUrl && requestUrl.headers) {
-      return requestUrl.headers;
-    } else {
-      return {};
-    }
-  };
-
   const getRequestUrl = (requestUrl) => {
     if (requestUrl) {
       if (requestUrl.useOnPlatform === 'all') {
@@ -128,6 +120,14 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       }
     } else {
       return 'https://maps.googleapis.com/maps/api';
+    }
+  };
+
+  const getRequestHeaders = (requestUrl) => {
+    if (requestUrl) {
+      return requestUrl.headers;
+    } else {
+      return {};
     }
   };
 
@@ -164,7 +164,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   }, []);
   useEffect(() => {
     // Update dataSource if props.predefinedPlaces changed
-    setDataSource(buildRowsFromResults([])) 
+    setDataSource(buildRowsFromResults([]))
   }, [props.predefinedPlaces])
 
   useImperativeHandle(ref, () => ({
@@ -320,7 +320,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(props.requestUrl));
 
       request.send();
     } else if (rowData.isCurrentLocation === true) {
@@ -480,7 +480,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       request.open('GET', requestUrl);
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(props.requestUrl));
 
       request.send();
     } else {
@@ -544,7 +544,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       );
 
       request.withCredentials = requestShouldUseWithCredentials();
-      setRequestHeaders(request, headers);
+      setRequestHeaders(request, getRequestHeaders(requestUrl));
 
       request.send();
     } else {

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ export default GooglePlacesInput;
 
 Web support can be enabled via the `requestUrl` prop, by passing in a URL that you can use to proxy your requests. CORS implemented by the Google Places API prevent using this library directly on the web. You will need to use a proxy server. Please be mindful of this limitation when opening an issue.
 
-The `requestUrl` prop takes an object with two properties: `useOnPlatform` and `url`.
+The `requestUrl` prop takes an object with two required properties: `useOnPlatform` and `url`, and an optional `headers` property.
 
 The `url` property is used to set the url that requests will be made to. If you are using the regular google maps API, you need to make sure you are ultimately hitting https://maps.googleapis.com/maps/api.
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ The `url` property is used to set the url that requests will be made to. If you 
 
 `useOnPlatform` configures when the proxy url is used. It can be set to either `web`- will be used only when the device platform is detected as web (but not iOS or Android, or `all` - will always be used.
 
+You can optionally specify headers to apply to your request in the `headers` object. 
+
 ### Example:
 
 ```js
@@ -432,6 +434,9 @@ const GooglePlacesInput = () => {
         useOnPlatform: 'web', // or "all"
         url:
           'https://cors-anywhere.herokuapp.com/https://maps.googleapis.com/maps/api', // or any proxy server that hits https://maps.googleapis.com/maps/api
+        headers: {
+          Authorization: `an auth token` // if required for your proxy
+        }
       }}
     />
   );


### PR DESCRIPTION
A more generalized version of https://github.com/FaridSafi/react-native-google-places-autocomplete/pull/660 that allows arbitrary headers to be specified when using a custom `requestUrl`. It determines the headers at request time so that values can be specified dynamically.

Our use case is adding an Authorization header to proxied Google requests. The custom proxy allows us to append the Google API key server side so it is not exposed via app traffic (as we can not use a restricted key with this library). We also need to guard against unauthorized usage of the proxy.

Example usage:
```
requestUrl={{
  url: MY_PROXY,
  useOnPlatform: "all",
  headers: {
    Authorization: `Bearer ${accessToken}`,
   },
```