### PR TITLE
Hide results when network request fails

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -479,6 +479,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         }
 
         if (request.status === 200) {
+          setListViewDisplayed(true);
           const responseJSON = JSON.parse(request.responseText);
           if (typeof responseJSON.predictions !== 'undefined') {
             // if (_isMounted === true) {
@@ -504,6 +505,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             }
           }
         } else {
+          setListViewDisplayed(false);
           // console.warn("google places autocomplete: request could not be completed or has been aborted");
         }
       };


### PR DESCRIPTION
This is to dismiss the suggestion box if the request fails during user interactions, so it doesn't obstruct the UI and allowing the user to finish their workflow.

Currently if the request stopped coming in during an address input, the box will continue to display previously fetched suggestions (can consider them as staled results). And the box is also blocking the rest of the form (assuming there are more fields underneath).

This PR is to propose the usage of `setListViewDisplayed` during the request status callback, and toggle the display state accordingly.