### PR TITLE
Fix broken link to Google Places API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add react-native-google-places-autocomplete
 
 **Step 2.**
 
-Get your [Google Places API keys](https://developers.google.com/places/documentation/) and enable "Google Places API Web Service" (NOT Android or iOS) in the console. Billing must be enabled on the account.
+Get your [Google Places API keys](https://developers.google.com/maps/documentation/places/web-service/get-api-key/) and enable "Google Places API Web Service" (NOT Android or iOS) in the console. Billing must be enabled on the account.
 
 **Step 3.**
 


### PR DESCRIPTION
Installation section of README.md contains a broken link to the Google Places API documentation.