### PR TITLE
Update getRequestHeaders to always return an object

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -124,11 +124,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   };
 
   const getRequestHeaders = (requestUrl) => {
-    if (requestUrl) {
-      return requestUrl.headers;
-    } else {
-      return {};
-    }
+    return requestUrl?.headers || {};
   };
 
   const setRequestHeaders = (request, headers) => {


### PR DESCRIPTION
Currently the package is breaking if you do not inform `headers` on the `requestUrl` prop.

![Screen Shot 2021-08-10 at 16 09 47](https://user-images.githubusercontent.com/14919996/128920615-5fa458cb-e0be-4b61-afd9-9feb2c7fc049.png)
