### PR TITLE
Feature / Ability to use optional gesture handler based on `useGestureTouchableHighlight` prop type

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -427,6 +427,7 @@ interface GooglePlacesAutocompleteProps {
   /** text input props */
   textInputProps?: TextInputProps | Object;
   timeout?: number;
+  useGestureTouchableHighlight: boolean,
 }
 
 export type GooglePlacesAutocompleteRef = {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -19,9 +19,11 @@ import {
   ScrollView,
   Text,
   TextInput,
-  TouchableHighlight,
   View,
+  TouchableHighlight as StandardTouchableHighlight
 } from 'react-native';
+
+import { TouchableHighlight as GestureTouchableHighlight} from 'react-native-gesture-handler';
 
 const defaultStyles = {
   container: {
@@ -624,7 +626,8 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
       >
-        <TouchableHighlight
+        {!props.useGestureTouchableHighlight &&
+        <StandardTouchableHighlight
           style={
             props.isRowScrollable ? { minWidth: '100%' } : { width: '100%' }
           }
@@ -641,7 +644,28 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             {_renderLoader(rowData)}
             {_renderRowData(rowData, index)}
           </View>
-        </TouchableHighlight>
+        </StandardTouchableHighlight>
+        }
+        {props.useGestureTouchableHighlight &&
+        <GestureTouchableHighlight
+          style={
+            props.isRowScrollable ? { minWidth: '100%' } : { width: '100%' }
+          }
+          onPress={() => _onPress(rowData)}
+          underlayColor={props.listUnderlayColor || '#c8c7cc'}
+        >
+          <View
+            style={[
+              props.suppressDefaultStyles ? {} : defaultStyles.row,
+              props.styles.row,
+              rowData.isPredefinedPlace ? props.styles.specialItemRow : {},
+            ]}
+          >
+            {_renderLoader(rowData)}
+            {_renderRowData(rowData, index)}
+          </View>
+        </GestureTouchableHighlight>
+        }
       </ScrollView>
     );
   };
@@ -896,6 +920,7 @@ GooglePlacesAutocomplete.propTypes = {
   textInputHide: PropTypes.bool,
   textInputProps: PropTypes.object,
   timeout: PropTypes.number,
+  useGestureTouchableHighlight: PropTypes.bool,
 };
 
 GooglePlacesAutocomplete.defaultProps = {
@@ -939,6 +964,7 @@ GooglePlacesAutocomplete.defaultProps = {
   textInputHide: false,
   textInputProps: {},
   timeout: 20000,
+  useGestureTouchableHighlight: false,
 };
 
 export default { GooglePlacesAutocomplete };


### PR DESCRIPTION
Ability to use library inside Swiper component. The reason of that was `TouchableHighlight` import from `react-native` instead of `react-native-gesture-handler` library.
Issue can be reproduced when `GooglePlacesAutocomplete` component is placed inside `Swiper` from `react-native-swiper` component.

Added the additional prop which is optional and if anyone want to use the `TouchableHighlight` from `react-native-gesture-handler` that will be possible. I did take a look and there are few the same changes in Forked repos so I think that could be added to original code to make the library work in other places where `TouchableHighlight` from `react-native` cannot be used.


https://user-images.githubusercontent.com/59608425/129886006-ff93c831-c0dd-4a5d-99d0-a7a83f0ea54e.mov