### PR TITLE
Fix parameter name in _getFlatList function

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -759,7 +759,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
         <FlatList
           nativeID='result-list-id'
           scrollEnabled={!props.disableScroll}
-          style={[
+          contentContainerStyle={[
             props.suppressDefaultStyles ? {} : defaultStyles.listView,
             props.styles.listView,
           ]}


### PR DESCRIPTION
According to my issue (#792) I make this pull request to let listView's borderRadius style work in Android devices as well.
There was a wrong parameter name in the _getFlatList function. The fix is change the parameter name from style to contentContainerStyle.
Please review, thank you.
