### PR TITLE
Added ref method setAddressTextAndQuery(address) to set address text AND query the input AUTOMATICALLY (with results list displayed upon text change)

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -160,6 +160,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     setAddressText: (address) => {
       setStateText(address);
     },
+    setAddressTextAndQuery: (address) => {
+     _handleChangeText(address);
++     setListViewDisplayed(true); 
+    },
     getAddressText: () => stateText,
     blur: () => inputRef.current.blur(),
     focus: () => inputRef.current.focus(),


### PR DESCRIPTION
This change introduces a **new method `setAddressTextAndQuery(address)`** that can be used by refs 🎉🎊🙌 !  **It changes the address text to the provided address and then queries the input automatically.** Using `_handleChangeText(address)` and `setListViewDisplayed(true)`, it also shows the list of results (NOTE: This is not currently possible with `setAddressText(address)` alone...). This gives more flexibility to developers who would like to programmatically set the address text AND then query the input AND display the results lists directly from their refs.

Note: This change does not affect pre-existing functionality. It only adds further functionality through a single simple function. Therefore, there are no conflicts created.