### PR TITLE
Fix illegal invocation issue

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -201,7 +201,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       };
     }
     const getCurrentPosition =
-      navigator.geolocation.getCurrentPosition ||
+      (navigator.geolocation.getCurrentPosition && navigator.geolocation.getCurrentPosition.bind(navigator.geolocation)) ||
       navigator.geolocation.default.getCurrentPosition;
 
     getCurrentPosition &&


### PR DESCRIPTION
Currently on web assigning navigator.geolocation to a variable loses the "this" context of the getCurrentPosition method resulting in an "Illegal invocation" error