### PR TITLE
Added event object to `onBlur` method sent through `textInputProps`

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -821,7 +821,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
               onFocus
                 ? () => {
                     _onFocus();
-                    onFocus();
+                    onFocus(e);
                   }
                 : _onFocus
             }

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -829,7 +829,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
               onBlur
                 ? (e) => {
                     _onBlur(e);
-                    onBlur();
+                    onBlur(e);
                   }
                 : _onBlur
             }


### PR DESCRIPTION
It would be good to send the `event` object to the `onBlur` method set in `textInputProps` by the user. Otherwise, end users might have issues using libraries like `formik` for validation. 