### PR TITLE
fix: fix irregular separator height

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -17,6 +17,7 @@ import {
   Keyboard,
   Platform,
   ScrollView,
+  StyleSheet,
   Text,
   TextInput,
   TouchableHighlight,
@@ -54,7 +55,7 @@ const defaultStyles = {
   },
   description: {},
   separator: {
-    height: 0.5,
+    height: StyleSheet.hairlineWidth,
     backgroundColor: '#c8c7cc',
   },
   poweredContainer: {


### PR DESCRIPTION
observe those 3 separators. heights look irregular. (ref the screenshot below)
<a href="https://ibb.co/mG9B7m1"><img src="https://i.ibb.co/zrX5w1j/Studio-Project.jpg" alt="Studio-Project" border="0"></a>


fixed it using `StyleSheet.harlineWidth`. now lines are of same height