### PR TITLE
added location and radius for places search

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -936,6 +936,8 @@ GooglePlacesAutocomplete.defaultProps = {
     key: 'missing api key',
     language: 'en',
     types: 'geocode',
+    location:'missing lnt and lng',
+    radius: 2000
   },
   styles: {},
   suppressDefaultStyles: false,


### PR DESCRIPTION
If the user wants to search places within the restricted area using latitude and longitude and within the required radius I have added in the query so the user can pass these values as a props

`location -  lnt and lng string (ex. '2.232-3.343')`
`radius - number (ex. 2000)`
