### PR TITLE
Surface non-200 request errors

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -517,7 +517,11 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             }
           }
         } else {
-          // console.warn("google places autocomplete: request could not be completed or has been aborted");
+          if (!props.onFail)
+            console.warn(`google places autocomplete: ${request.status}: ${request.statusText}. ${request.responseText}`);
+          else {
+            props.onFail(`${request.status}: ${request.statusText}. ${request.responseText}`);
+          }
         }
       };
 


### PR DESCRIPTION
Currently, if a request to the Google Places API fails with a non-200 status code, there is no console warning, and the `onFail` callback is not called. This PR fixes that, so that the errors can be surfaced.

An example case is if `requestUrl` uses the Google API without a proxy, or if the proxy does not have allow-origin CORS headers, then the request fails with a `403`, forbidden status. Currently, those cases fail silently, so this PR fixes that, allowing users to specify an error handler and surface the error.