### PR TITLE
Bug Fix: This fix makes the component stop failing silently when user doesn't specify onFail prop

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -478,6 +478,16 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       setDataSource(buildRowsFromResults([]));
     }
   };
+  
+  const _onFail = (message) => {
+    if (!props.onFail)
+      console.warn(
+        'google places autocomplete: ' + message,
+      );
+    else {
+      props.onFail(message);
+    }
+  };
 
   const _request = (text) => {
     _abortRequests();
@@ -508,16 +518,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
             // }
           }
           if (typeof responseJSON.error_message !== 'undefined') {
-            if (!props.onFail)
-              console.warn(
-                'google places autocomplete: ' + responseJSON.error_message,
-              );
-            else {
-              props.onFail(responseJSON.error_message);
-            }
+            _onFail(responseJSON.error_message);
           }
         } else {
-          // console.warn("google places autocomplete: request could not be completed or has been aborted");
+          _onFail("request could not be completed or has been aborted");
         }
       };
 
@@ -925,7 +929,7 @@ GooglePlacesAutocomplete.defaultProps = {
   minLength: 0,
   nearbyPlacesAPI: 'GooglePlacesSearch',
   numberOfLines: 1,
-  onFail: () => {},
+  onFail: undefined,
   onNotFound: () => {},
   onPress: () => {},
   onTimeout: () => console.warn('google places autocomplete: request timeout'),


### PR DESCRIPTION
This way, the default onFail behavior will occur for users who don't specify one (currently, the default behavior of calling `console.warn` isn't reachable code).

I spent 2 hours trying to figure out why it was silently failing. Had to manually edit the code locally to figure out the issue (my API key had restrictions) but had this PR already been in place it would've taken seconds. Hopefully this helps someone else.