### PR TITLE
Fix onChange handler for search results after manually setting text input

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import Qs from 'qs';
 import React, {
   forwardRef,
-  useMemo,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -159,7 +159,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
   useImperativeHandle(ref, () => ({
     setAddressText: (address) => {
-      setStateText(address);
+      _handleChangeText(address);
     },
     getAddressText: () => stateText,
     blur: () => inputRef.current.blur(),


### PR DESCRIPTION
As per Issue https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/654, this change from `setStateText` to `_handleChangeText` will successfully fulfill autocomplete search results once an address is manually inputted via ref. 

Thanks!