### PR TITLE
Dynamic address addition, querying addresses, and selecting the first option.

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -431,6 +431,7 @@ interface GooglePlacesAutocompleteProps {
 }
 
 export type GooglePlacesAutocompleteRef = {
+  setAddressTextAndQuery(address: string): void;
   setAddressText(address: string): void;
   getAddressText(): string;
   getCurrentLocation(): void;

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -158,6 +158,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
   }, [props.predefinedPlaces]);
 
   useImperativeHandle(ref, () => ({
+    setAddressTextAndQuery:(address) => {
+      setStateText(address);
+      _handleAddressTextAndQuery(address);
+    },
     setAddressText: (address) => {
       setStateText(address);
     },
@@ -560,6 +564,28 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
 
     if (onChangeText) {
       onChangeText(text);
+    }
+  };
+
+  const _handleAddressTextAndQuery = async (address) => {
+
+    // Use Promise to ensure that the query is completed before logging addresses
+    await new Promise((resolve) => {
+      // Trigger the query to fetch autocomplete results based on the entered address
+      _request(address);
+
+      // Wait for a short delay to ensure the query is completed and results are available
+      setTimeout(() => {
+        resolve(dataSource);
+      }, 500); // Adjust the delay as needed
+    });
+
+    if (_results.length > 0) {
+      // Get the first item from _results
+      const firstResult = _results[0];
+
+      // Trigger the onPress function with the first result
+      _onPress(firstResult);
     }
   };
 


### PR DESCRIPTION
Adding setAddressTextAndQuery to pick first option when setting up address dynamically.

Demo: [Watch the demo on YouTube](https://youtu.be/KcZ_-CprJ7k)

Starting State:
![1](https://github.com/FaridSafi/react-native-google-places-autocomplete/assets/18272791/b6531894-52f1-44a2-a63b-dac834dcfdf9)

Inserting Address Dynamically:
![2](https://github.com/FaridSafi/react-native-google-places-autocomplete/assets/18272791/f7e9206a-0f6c-4d14-a4fa-a5f6771cef7f)

Selecting First Queried Option:
![3](https://github.com/FaridSafi/react-native-google-places-autocomplete/assets/18272791/a4774eee-f986-4b08-95d1-c45b56464323)
