### PR TITLE
fix: textInput default value causing flicker

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -431,6 +431,7 @@ interface GooglePlacesAutocompleteProps {
   /** text input props */
   textInputProps?: TextInputProps | Object;
   timeout?: number;
+  defaultValue?: string;
 }
 
 export type GooglePlacesAutocompleteRef = {

--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -262,7 +262,7 @@ interface MatchedSubString {
 
 interface Term {
   offset: number;
-  value: string;
+  value?: string;
 }
 
 interface StructuredFormatting {

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -858,6 +858,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
               props.styles.textInput,
             ]}
             value={stateText}
+            defaultValue={props.defaultValue}
             placeholder={props.placeholder}
             onFocus={
               onFocus
@@ -942,6 +943,7 @@ GooglePlacesAutocomplete.propTypes = {
   textInputHide: PropTypes.bool,
   textInputProps: PropTypes.object,
   timeout: PropTypes.number,
+  defaultValue: PropTypes.string,
 };
 
 GooglePlacesAutocomplete.defaultProps = {
@@ -986,6 +988,7 @@ GooglePlacesAutocomplete.defaultProps = {
   textInputHide: false,
   textInputProps: {},
   timeout: 20000,
+  defaultValue: '',
 };
 
 GooglePlacesAutocomplete.displayName = 'GooglePlacesAutocomplete';

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -862,8 +862,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
               props.suppressDefaultStyles ? {} : defaultStyles.textInput,
               props.styles.textInput,
             ]}
-            value={stateText}
-            defaultValue={props.defaultValue}
+            {...(stateText ? { value: stateText } : { defaultValue: props.defaultValue })}
             placeholder={props.placeholder}
             onFocus={
               onFocus

--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -150,7 +150,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     );
   };
 
-  const [stateText, setStateText] = useState('');
+  const [stateText, setStateText] = useState(props.defaultValue || '');
   const [dataSource, setDataSource] = useState(buildRowsFromResults([]));
   const [listViewDisplayed, setListViewDisplayed] = useState(
     props.listViewDisplayed === 'auto' ? false : props.listViewDisplayed,
@@ -177,6 +177,10 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     // Update dataSource if props.predefinedPlaces changed
     setDataSource(buildRowsFromResults([]));
   }, [buildRowsFromResults, props.predefinedPlaces]);
+
+  useEffect(() => {
+    setStateText(props.defaultValue || '');
+  }, [props.defaultValue]);
 
   useImperativeHandle(ref, () => ({
     setAddressText: (address) => {
@@ -835,6 +839,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
     ...userProps
   } = props.textInputProps;
   const TextInputComp = InputComp || TextInput;
+  console.log(props.defaultValue);
   return (
     <View
       style={[


### PR DESCRIPTION
An issue with react natives textInput is when the value is set (you want the value preset before user changes) and the user tries to edit the value, it causes flicker and inability to edit. This fix allows the user the pass defaultValue which is another prop that textInput takes and works as expected.