### PR TITLE
feat: add None type for nearbyPlacesAPI

### DIFF
--- a/GooglePlacesAutocomplete.d.ts
+++ b/GooglePlacesAutocomplete.d.ts
@@ -404,7 +404,7 @@ interface GooglePlacesAutocompleteProps {
   minLength?: number;
   keepResultsAfterBlur?: boolean;
   /** Which API to use: GoogleReverseGeocoding or GooglePlacesSearch */
-  nearbyPlacesAPI?: 'GoogleReverseGeocoding' | 'GooglePlacesSearch';
+  nearbyPlacesAPI?: 'GoogleReverseGeocoding' | 'GooglePlacesSearch' | 'None';
   numberOfLines?: number;
   onFail?: (error?: any) => void;
   onNotFound?: () => void;


### PR DESCRIPTION
Fixes: TypeScript issue when trying to use `nearbyPlacesAPI='None'`.

Setting None so that pressing 'Current Location' triggers `onPress` as described in this issue https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/85