### PR TITLE
fix: Add polyfill for crypto.getRandomValues in React Native

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -2,6 +2,7 @@
 import debounce from 'lodash.debounce';
 import PropTypes from 'prop-types';
 import Qs from 'qs';
+import 'react-native-get-random-values';
 import { v4 as uuidv4 } from 'uuid';
 import React, {
   forwardRef,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash.debounce": "^4.0.8",
     "prop-types": "^15.7.2",
     "qs": "~6.9.1",
+    "react-native-get-random-values": "^1.11.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds a polyfill for the global `crypto.getRandomValues` method in React Native by installing `react-native-get-random-values`. This polyfill is required because React Native does not natively support `crypto.getRandomValues`, which is used by `uuid` and other libraries that rely on it for random ID generation.

The polyfill ensures that these libraries can function correctly in a React Native environment without causing the "Error: crypto.getRandomValues() not supported" issue.

Fixes #950.
