### PR TITLE
fix: get default props issue

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import Qs from 'qs';
 import { v4 as uuidv4 } from 'uuid';
 import React, {
-  forwardRef,
   useMemo,
   useEffect,
   useImperativeHandle,
@@ -71,7 +70,7 @@ const defaultStyles = {
   powered: {},
 };
 
-export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
+export const GooglePlacesAutocomplete = ({ref, ...props}) => {
   let _results = [];
   let _requests = [];
 
@@ -958,7 +957,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
       {props.children}
     </View>
   );
-});
+};
 
 GooglePlacesAutocomplete.propTypes = {
   autoFillOnNotFound: PropTypes.bool,


### PR DESCRIPTION
## Description
We don't need to use `forwardRef` in React 19, because we can get `ref` from component props
https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop

## Issue
https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/963
