### PR TITLE
Merge default props - Fixes defaultProps related issues

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -71,7 +71,15 @@ const defaultStyles = {
   powered: {},
 };
 
-export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
+export const GooglePlacesAutocomplete = forwardRef((providedProps, ref) => {
+  let props = useMemo(
+    () => ({
+      ...defaultProps,
+      ...providedProps,
+    }),
+    [providedProps],
+  );
+
   let _results = [];
   let _requests = [];
 
@@ -1017,7 +1025,7 @@ GooglePlacesAutocomplete.propTypes = {
   fields: PropTypes.string,
 };
 
-GooglePlacesAutocomplete.defaultProps = {
+let defaultProps = {
   autoFillOnNotFound: false,
   currentLocation: false,
   currentLocationLabel: 'Current location',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,6 +1780,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
 v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"


### PR DESCRIPTION
New versions of react don't apply defaultProps, and the current code depends on defaultProps to merge props.

But since defaultProps are not applied we get errors like `cannot read property of undefined` when trying to do `predefinedPlaces.filter`.

As a workaround people are passing values of default props manually like `predefinedPlaces=[]`, `minLength={3}` etc.

I think these issues would get fixed by applying defaultProps.

https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/980
https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/979
https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/976

Also i've included uuid in lock file, it was in package.json but not in yarn.lock