### PR TITLE
fix: respect keyboardShouldPersistTaps in FlatList

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -1010,6 +1010,7 @@ export const GooglePlacesAutocomplete = forwardRef((props, ref) => {
           nativeID='result-list-id'
           scrollEnabled={!disableScroll}
           nestedScrollEnabled={true}
+          keyboardShouldPersistTaps={keyboardShouldPersistTaps}
           style={[
             suppressDefaultStyles ? {} : defaultStyles.listView,
             styles?.listView,


### PR DESCRIPTION
## onPress not called on first tap in GooglePlacesAutocomplete

### What's the issue?
The internal `FlatList` never forwards `keyboardShouldPersistTaps`, so even if caller sets it to `'handled'` or `'always'`, the first tap always closes the keyboard without firing `onPress`.


### How to reproduce?
```tsx
<GooglePlacesAutocomplete
    keyboardShouldPersistTaps="handled"
    placeholder="Keyboard Tap Test"
    query={{ key: GOOGLE_MAPS_API_KEY }}
/>
```
Type any query and tap a result -> keyboard hides, item is not selected until you tap again.



### Proposed changes
Pass component's `keyboardShouldPersistTaps` prop to the FlatList:
```tsx
<FlatList
  ...
  keyboardShouldPersistTaps={keyboardShouldPersistTaps}
```
Now the list respects the prop (defaults to 'always'), so first tap hits the row immediately.



